### PR TITLE
yamet updates

### DIFF
--- a/method/.clang-format
+++ b/method/.clang-format
@@ -1,0 +1,18 @@
+BasedOnStyle: LLVM
+IndentWidth: 2
+TabWidth: 4
+UseTab: Never
+AllowShortFunctionsOnASingleLine: Empty
+ColumnLimit: 100
+PointerAlignment: Right
+SpaceBeforeParens: ControlStatements
+
+CommentPragmas: "^ IWYU pragma:"
+
+SortIncludes: true
+
+ReflowComments: true
+
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlines: Left # Options: Don't, Left, Right.

--- a/method/code/align.cpp
+++ b/method/code/align.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <future>
 #include <iostream>
 #include <sstream>
@@ -35,7 +36,8 @@ void alignSingleWithRef(const std::string &filename, Reference &ref, FileMap &fi
   FileMeths meths;
 
   for (const auto &[chr, positions] : ref) {
-    meths.emplace_back(chr, std::vector<std::vector<char>>(positions.size(), std::vector<char>()));
+    meths.emplace_back(chr,
+                       std::vector<std::vector<int8_t>>(positions.size(), std::vector<int8_t>()));
   }
 
   unsigned int chrIndex = 0, binIndex = 0, posIndex = 0;

--- a/method/code/align.cpp
+++ b/method/code/align.cpp
@@ -76,7 +76,7 @@ void alignSingleWithRef(const std::string &filename, Reference &ref, FileMap &fi
       std::istringstream lineStream(line);
       std::string        chr, temp;
       unsigned int       pos;
-      char               methValue;
+      unsigned int       methValue;
       lineStream >> chr >> pos >> temp >> temp >> methValue;
 
       if (chr != currentChr) {

--- a/method/code/align.cpp
+++ b/method/code/align.cpp
@@ -1,6 +1,5 @@
 #include <atomic>
 #include <condition_variable>
-#include <cstdint>
 #include <iostream>
 #include <mutex>
 #include <queue>
@@ -9,15 +8,16 @@
 #include <unordered_map>
 #include <zlib.h>
 
-#include <chrData.h>
-#include <methData.h>
-
 #if defined(__linux__) || defined(__APPLE__)
 #include <pthread.h>
 #include <sched.h>
 #elif defined(_WIN32) // Windows
 #include <windows.h>
 #endif
+
+#include <align.h>
+#include <chrData.h>
+#include <methData.h>
 
 /**
  * Parse a tab separated file of all covered positions of a reference genome into a nested structure
@@ -47,8 +47,7 @@ void alignSingleWithRef(const std::string &filename, Reference &ref, FileMap &fi
   FileMeths meths;
 
   for (const auto &[chr, positions] : ref) {
-    meths.emplace_back(chr,
-                       std::vector<std::vector<int8_t>>(positions.size(), std::vector<int8_t>()));
+    meths.emplace_back(chr, positions.size());
   }
 
   unsigned int chrIndex = 0, binIndex = 0, posIndex = 0;

--- a/method/code/align.cpp
+++ b/method/code/align.cpp
@@ -124,7 +124,7 @@ void alignSingleWithRef(const std::string &filename, Reference &ref, FileMap &fi
         }
       }
     }
-    if (bytesRead < bufferSize - 1) {
+    if (bytesRead < bufferSize - 1 && partialLine.empty()) {
       break;
     }
   }

--- a/method/code/align.cpp
+++ b/method/code/align.cpp
@@ -1,44 +1,39 @@
+#include <future>
 #include <iostream>
-#include <zlib.h>
 #include <sstream>
 #include <unordered_map>
-#include <future>
+#include <zlib.h>
 
 #include <chrData.h>
 #include <methData.h>
 
-void alignSingleWithRef(const std::string &filename, Reference &ref, FileMap &fileMap)
-{
+void alignSingleWithRef(const std::string &filename, Reference &ref, FileMap &fileMap) {
   gzFile file = gzopen(filename.c_str(), "rb");
-  if (!file)
-  {
+  if (!file) {
     std::cerr << "Failed to open file: " << filename << std::endl;
   }
 
   constexpr int bufferSize = 64 * 1024;
-  char buffer[bufferSize];
-  std::string partialLine;
-  bool headerSkipped = false;
+  char          buffer[bufferSize];
+  std::string   partialLine;
+  bool          headerSkipped = false;
 
   FileMeths meths;
 
-  for (const auto &[chr, positions] : ref)
-  {
+  for (const auto &[chr, positions] : ref) {
     meths.emplace_back(chr, std::vector<std::vector<char>>(positions.size(), std::vector<char>()));
   }
 
   unsigned int chrIndex = 0, binIndex = 0, posIndex = 0;
-  bool start = true;
-  std::string currentChr = "";
-  bool foundChr = false;
-  int lastBinPos = -1;
+  bool         start      = true;
+  std::string  currentChr = "";
+  bool         foundChr   = false;
+  int          lastBinPos = -1;
 
-  while (true)
-  {
+  while (true) {
     int bytesRead = gzread(file, buffer, bufferSize - 1);
 
-    if (bytesRead < 0)
-    {
+    if (bytesRead < 0) {
       std::cerr << "Error reading gzip file" << std::endl;
       gzclose(file);
     }
@@ -49,121 +44,105 @@ void alignSingleWithRef(const std::string &filename, Reference &ref, FileMap &fi
     partialLine.clear();
 
     std::istringstream ss(fullBuffer);
-    std::string line;
+    std::string        line;
 
-    while (std::getline(ss, line))
-    {
-      if (ss.eof() && line.back() != '\n')
-      {
+    while (std::getline(ss, line)) {
+      if (ss.eof() && line.back() != '\n') {
         partialLine = line;
         break;
       }
-      if (!headerSkipped)
-      {
+      if (!headerSkipped) {
         headerSkipped = true;
         continue;
       }
       std::istringstream lineStream(line);
-      std::string chr, temp;
-      unsigned int pos;
-      char methValue;
+      std::string        chr, temp;
+      unsigned int       pos;
+      char               methValue;
       lineStream >> chr >> pos >> temp >> temp >> methValue;
 
-      if (chr != currentChr)
-      {
+      if (chr != currentChr) {
         binIndex = 0, posIndex = 0;
-        foundChr = false;
+        foundChr   = false;
         currentChr = chr;
-      }
-      else if (!foundChr)
-      {
+      } else if (!foundChr) {
         continue;
       }
 
-      if (!foundChr)
-      {
-        for (chrIndex = 0; chrIndex < ref.size(); chrIndex++)
-        {
-          if (ref[chrIndex].chr == chr)
-          {
+      if (!foundChr) {
+        for (chrIndex = 0; chrIndex < ref.size(); chrIndex++) {
+          if (ref[chrIndex].chr == chr) {
             foundChr = true;
             break;
           }
         }
-        if (!foundChr)
-        {
+        if (!foundChr) {
           continue;
         }
       }
 
-      while (true)
-      {
+      while (true) {
         // std::cout << chrIndex << "  " << binIndex << "  " << posIndex << std::endl;
         bool increment = false, exit = false;
-        if (ref[chrIndex].positions[binIndex].size() > 0)
-        {
-          if (pos == ref[chrIndex].positions[binIndex][posIndex])
-          {
-            if (lastBinPos > -1 && posIndex - lastBinPos > 1)
+        if (ref[chrIndex].positions[binIndex].size() > 0) {
+          if (pos == ref[chrIndex].positions[binIndex][posIndex]) {
+            if (lastBinPos > -1 && posIndex - lastBinPos > 1) {
               meths[chrIndex].meth[binIndex].push_back(-1);
+            }
             meths[chrIndex].meth[binIndex].push_back(methValue);
             increment = true, exit = true;
             lastBinPos = posIndex;
-          }
-          else if (pos < ref[chrIndex].positions[binIndex][posIndex])
+          } else if (pos < ref[chrIndex].positions[binIndex][posIndex])
             exit = true; // break;
-          else
+          else {
             increment = true;
-        }
-        else
-        {
-          if (binIndex == ref[chrIndex].positions.size() - 1)
+          }
+        } else {
+          if (binIndex == ref[chrIndex].positions.size() - 1) {
             exit = true; // break;
-          else
+          } else {
             binIndex += 1, posIndex = 0, lastBinPos = -1;
+          }
         }
-        if (increment)
-        {
-          if (binIndex == ref[chrIndex].positions.size() - 1)
-          {
-            if (posIndex == ref[chrIndex].positions[binIndex].size() - 1)
+        if (increment) {
+          if (binIndex == ref[chrIndex].positions.size() - 1) {
+            if (posIndex == ref[chrIndex].positions[binIndex].size() - 1) {
               lastBinPos = -1, exit = true;
-            else
+            } else {
               posIndex++;
-          }
-          else
-          {
-            if (posIndex == ref[chrIndex].positions[binIndex].size() - 1)
+            }
+          } else {
+            if (posIndex == ref[chrIndex].positions[binIndex].size() - 1) {
               binIndex += 1, lastBinPos = -1, posIndex = 0;
-            else
+            } else {
               posIndex++;
+            }
           }
         }
-        if (exit)
+        if (exit) {
           break;
+        }
       }
     }
-    if (bytesRead < bufferSize - 1)
+    if (bytesRead < bufferSize - 1) {
       break;
+    }
   }
   gzclose(file);
   fileMap[filename] = std::move(meths);
 }
 
-FileMap alignWithRef(const std::vector<std::string> &filenames, Reference &ref)
-{
+FileMap alignWithRef(const std::vector<std::string> &filenames, Reference &ref) {
   FileMap fileMap;
   fileMap.reserve(filenames.size());
   std::vector<std::future<void>> futures;
 
-  for (const auto &filename : filenames)
-  {
+  for (const auto &filename : filenames) {
     // Launch asynchronous tasks for each filename
-    futures.push_back(std::async(std::launch::async, [&]()
-                                 { alignSingleWithRef(filename, ref, fileMap); }));
+    futures.push_back(
+        std::async(std::launch::async, [&]() { alignSingleWithRef(filename, ref, fileMap); }));
   }
-  for (auto &future : futures)
-  {
+  for (auto &future : futures) {
     future.get();
   }
   return fileMap;

--- a/method/code/align.cpp
+++ b/method/code/align.cpp
@@ -124,7 +124,7 @@ void alignSingleWithRef(const std::string &filename, Reference &ref, FileMap &fi
         }
       }
     }
-    if (bytesRead < bufferSize - 1 && partialLine.empty()) {
+    if (bytesRead < bufferSize - 1) {
       break;
     }
   }

--- a/method/code/boost.cpp
+++ b/method/code/boost.cpp
@@ -1,5 +1,8 @@
+#include <cmath>
 #include <iostream>
 #include <stdexcept>
+#include <string>
+#include <thread>
 
 #include "boost.h"
 
@@ -17,14 +20,21 @@ po::variables_map parseCommandLine(int argc, char **argv) {
       "det-out,d", po::value<std::string>(), "(optional) path to detailed output file")(
       "out,o", po::value<std::string>(), "(optional) path to simple output file");
 
+  po::options_description res("resource utilisation");
+  res.add_options()("n-cores", po::value<int>()->default_value(0)->notifier(validate_num_cores),
+                    "number of cores used for simultaneously parsing methylation files")(
+      "n-threads-per-core",
+      po::value<unsigned int>()->default_value(1)->notifier(validate_num_threads_per_core),
+      "number of threads per core used for simultaneously parsing methylation files");
+
   po::options_description ver("verbose");
   ver.add_options()("print-bed", "print parsed regions file")(
       "print-ref", "print parsed reference file")("print-tsv", "print parsed cell files")(
-      "print-sampens", po::value<std::string>()->default_value("true"),
+      "print-sampens", po::value<std::string>()->default_value("true")->implicit_value("true"),
       "print computed sample entropies");
 
   po::options_description all;
-  all.add(gen).add(ver);
+  all.add(gen).add(res).add(ver);
 
   po::positional_options_description p;
   p.add("tsv", -1);
@@ -59,11 +69,47 @@ std::string getOut(const po::variables_map &vm) {
   return vm["out"].as<std::string>();
 }
 
+unsigned int getNCores(const po::variables_map &vm) {
+  const unsigned int max_cores = std::thread::hardware_concurrency();
+  const int          c         = vm["n-cores"].as<int>();
+  if (c == -1) {
+    return max_cores;
+  } else if (c == 0) {
+    return max_cores - (unsigned int)(std::floor(std::log2(max_cores)));
+  } else {
+    return c;
+  }
+}
+
+unsigned int getNThreadsPerCore(const po::variables_map &vm) {
+  return vm["n-threads-per-core"].as<unsigned int>();
+}
+
 bool printSampens(const po::variables_map &vm) {
   char t = (char)std::tolower(vm["print-sampens"].as<std::string>()[0]);
   if (t == 't' || t == '1') {
     return true;
   } else {
     return false;
+  }
+}
+
+void validate_num_cores(const int cores) {
+  const int max_cores = std::thread::hardware_concurrency();
+
+  if (cores < -1) {
+    throw po::error("Error: 'n-cores' set to " + std::to_string(cores) +
+                    " is invalid. It can be\n-1 : use all cores\n 0 : let the program decide\n>0 : "
+                    "specified number of cores");
+  } else if (cores > max_cores) {
+    throw po::error("Error: 'n-cores' set to " + std::to_string(cores) +
+                    " exceeds the maximum number of available cores, " + std::to_string(max_cores));
+  }
+}
+
+void validate_num_threads_per_core(const int n_threads_per_core) {
+  if (n_threads_per_core < 1) {
+    throw po::error("Error: 'n-threads-per-core' set to " + std::to_string(n_threads_per_core) +
+                    " is invalid. It must be atleast 1");
   }
 }

--- a/method/code/boost.cpp
+++ b/method/code/boost.cpp
@@ -1,3 +1,4 @@
+#include <boost/program_options.hpp>
 #include <cmath>
 #include <iostream>
 #include <stdexcept>

--- a/method/code/boost.cpp
+++ b/method/code/boost.cpp
@@ -19,7 +19,9 @@ po::variables_map parseCommandLine(int argc, char **argv) {
 
   po::options_description ver("verbose");
   ver.add_options()("print-bed", "print parsed regions file")(
-      "print-ref", "print parsed reference file")("print-tsv", "print parsed cell files");
+      "print-ref", "print parsed reference file")("print-tsv", "print parsed cell files")(
+      "print-sampens", po::value<std::string>()->default_value("true"),
+      "print computed sample entropies");
 
   po::options_description all;
   all.add(gen).add(ver);
@@ -55,4 +57,13 @@ std::string getDetOut(const po::variables_map &vm) {
 
 std::string getOut(const po::variables_map &vm) {
   return vm["out"].as<std::string>();
+}
+
+bool printSampens(const po::variables_map &vm) {
+  char t = (char)std::tolower(vm["print-sampens"].as<std::string>()[0]);
+  if (t == 't' || t == '1') {
+    return true;
+  } else {
+    return false;
+  }
 }

--- a/method/code/boost.cpp
+++ b/method/code/boost.cpp
@@ -8,24 +8,30 @@ namespace po = boost::program_options;
 po::variables_map parseCommandLine(int argc, char **argv) {
   po::variables_map vm;
 
-  po::options_description desc("yamet - allowed options");
-  desc.add_options()("help,h", "produce help message")(
+  po::options_description gen("general");
+  gen.add_options()("help,h", "produce help message")(
       "tsv,t", po::value<std::vector<std::string>>()->composing(),
       ".tsv files for different cells")("ref,r", po::value<std::string>(),
                                         "path to tsv.gz file for reference CpG sites")(
       "bed,b", po::value<std::string>(), "path to bed file for regions of interest")(
-      "chr", po::value<std::string>(), "(optional) chr of interest")(
       "det-out,d", po::value<std::string>(), "(optional) path to detailed output file")(
       "out,o", po::value<std::string>(), "(optional) path to simple output file");
+
+  po::options_description ver("verbose");
+  ver.add_options()("print-bed", "print parsed regions file")("print-ref",
+                                                              "print parsed reference file");
+
+  po::options_description all;
+  all.add(gen).add(ver);
 
   po::positional_options_description p;
   p.add("tsv", -1);
 
-  po::store(po::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
+  po::store(po::command_line_parser(argc, argv).options(all).positional(p).run(), vm);
   po::notify(vm);
 
   if (vm.count("help")) {
-    std::cout << desc << std::endl;
+    std::cout << "yamet" << std::endl << all << std::endl;
     throw std::runtime_error("Help message displayed");
   }
   return vm;
@@ -33,10 +39,6 @@ po::variables_map parseCommandLine(int argc, char **argv) {
 
 std::vector<std::string> getTsvFiles(const po::variables_map &vm) {
   return vm["tsv"].as<std::vector<std::string>>();
-}
-
-std::string getChr(const po::variables_map &vm) {
-  return vm["chr"].as<std::string>();
 }
 
 std::string getBed(const po::variables_map &vm) {

--- a/method/code/boost.cpp
+++ b/method/code/boost.cpp
@@ -18,8 +18,8 @@ po::variables_map parseCommandLine(int argc, char **argv) {
       "out,o", po::value<std::string>(), "(optional) path to simple output file");
 
   po::options_description ver("verbose");
-  ver.add_options()("print-bed", "print parsed regions file")("print-ref",
-                                                              "print parsed reference file");
+  ver.add_options()("print-bed", "print parsed regions file")(
+      "print-ref", "print parsed reference file")("print-tsv", "print parsed cell files");
 
   po::options_description all;
   all.add(gen).add(ver);

--- a/method/code/boost.cpp
+++ b/method/code/boost.cpp
@@ -5,12 +5,18 @@
 
 namespace po = boost::program_options;
 
-po::variables_map parseCommandLine(int argc, char **argv)
-{
+po::variables_map parseCommandLine(int argc, char **argv) {
   po::variables_map vm;
 
   po::options_description desc("yamet - allowed options");
-  desc.add_options()("help,h", "produce help message")("tsv,t", po::value<std::vector<std::string>>()->composing(), ".tsv files for different cells")("ref,r", po::value<std::string>(), "path to tsv.gz file for reference CpG sites")("bed,b", po::value<std::string>(), "path to bed file for regions of interest")("chr", po::value<std::string>(), "(optional) chr of interest")("det-out,d", po::value<std::string>(), "(optional) path to detailed output file")("out,o", po::value<std::string>(), "(optional) path to simple output file");
+  desc.add_options()("help,h", "produce help message")(
+      "tsv,t", po::value<std::vector<std::string>>()->composing(),
+      ".tsv files for different cells")("ref,r", po::value<std::string>(),
+                                        "path to tsv.gz file for reference CpG sites")(
+      "bed,b", po::value<std::string>(), "path to bed file for regions of interest")(
+      "chr", po::value<std::string>(), "(optional) chr of interest")(
+      "det-out,d", po::value<std::string>(), "(optional) path to detailed output file")(
+      "out,o", po::value<std::string>(), "(optional) path to simple output file");
 
   po::positional_options_description p;
   p.add("tsv", -1);
@@ -18,40 +24,33 @@ po::variables_map parseCommandLine(int argc, char **argv)
   po::store(po::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
   po::notify(vm);
 
-  if (vm.count("help"))
-  {
+  if (vm.count("help")) {
     std::cout << desc << std::endl;
     throw std::runtime_error("Help message displayed");
   }
   return vm;
 }
 
-std::vector<std::string> getTsvFiles(const po::variables_map &vm)
-{
+std::vector<std::string> getTsvFiles(const po::variables_map &vm) {
   return vm["tsv"].as<std::vector<std::string>>();
 }
 
-std::string getChr(const po::variables_map &vm)
-{
+std::string getChr(const po::variables_map &vm) {
   return vm["chr"].as<std::string>();
 }
 
-std::string getBed(const po::variables_map &vm)
-{
+std::string getBed(const po::variables_map &vm) {
   return vm["bed"].as<std::string>();
 }
 
-std::string getRef(const po::variables_map &vm)
-{
+std::string getRef(const po::variables_map &vm) {
   return vm["ref"].as<std::string>();
 }
 
-std::string getDetOut(const po::variables_map &vm)
-{
+std::string getDetOut(const po::variables_map &vm) {
   return vm["det-out"].as<std::string>();
 }
 
-std::string getOut(const po::variables_map &vm)
-{
+std::string getOut(const po::variables_map &vm) {
   return vm["out"].as<std::string>();
 }

--- a/method/code/export.cpp
+++ b/method/code/export.cpp
@@ -5,6 +5,14 @@
 #include "methData.h"
 #include "samp_en.h"
 
+/**
+ * Exports a .tsv file with sample entropies per region for every cell file
+ *
+ * @param out path to .tsv file where detailed sample entropy outputs are to be stored
+ * @param filenames vector of filenames of all cell files
+ * @param sampens SampEns object with detailed sample entropy data
+ * @param intervals Intervals object with search intervals
+ */
 void exportDetOut(const std::string &out, const std::vector<std::string> &filenames,
                   SampEns &sampens, Intervals &intervals) {
   std::ofstream outStream(out);
@@ -21,8 +29,10 @@ void exportDetOut(const std::string &out, const std::vector<std::string> &filena
 
   for (unsigned int i = 0; i < intervals.size(); i++) {
     for (unsigned int j = 0; j < intervals[i].intervals.size(); j++) {
+      // print the region information
       outStream << intervals[i].chr << "\t" << intervals[i].intervals[j].start << "\t"
                 << intervals[i].intervals[j].end;
+      // print sample entropies for all files at that region
       for (const auto &filename : filenames) {
         outStream << "\t" << sampens[filename].raw[i][j];
       }
@@ -32,6 +42,13 @@ void exportDetOut(const std::string &out, const std::vector<std::string> &filena
   outStream.close();
 }
 
+/**
+ * Exports a .tsv file with sample entropies aggregated for every cell file
+ *
+ * @param out path to .tsv file where sample entropy outputs are to be stored
+ * @param filenames vector of filenames of all cell files
+ * @param sampens SampEns object with detailed sample entropy data
+ */
 void exportOut(const std::string &out, const std::vector<std::string> &filenames,
                SampEns &sampens) {
   std::ofstream outStream(out);
@@ -42,6 +59,7 @@ void exportOut(const std::string &out, const std::vector<std::string> &filenames
   }
   outStream << "file\tvalue" << std::endl;
 
+  // print aggregated sample entropy for each file
   for (const auto &filename : filenames) {
     outStream << filename << "\t" << sampens[filename].agg;
     outStream << std::endl;

--- a/method/code/export.cpp
+++ b/method/code/export.cpp
@@ -6,12 +6,12 @@
 #include "samp_en.h"
 
 /**
- * Exports a .tsv file with sample entropies per region for every cell file
+ * Exports a tab separated file with sample entropies per region for every cell file.
  *
- * @param out path to .tsv file where detailed sample entropy outputs are to be stored
- * @param filenames vector of filenames of all cell files
- * @param sampens SampEns object with detailed sample entropy data
- * @param intervals Intervals object with search intervals
+ * @param out path to tab separated file where detailed sample entropy outputs are to be stored.
+ * @param filenames vector of filenames of all cell files.
+ * @param sampens SampEns object with detailed sample entropy data.
+ * @param intervals Intervals object with search intervals.
  */
 void exportDetOut(const std::string &out, const std::vector<std::string> &filenames,
                   SampEns &sampens, Intervals &intervals) {
@@ -29,10 +29,10 @@ void exportDetOut(const std::string &out, const std::vector<std::string> &filena
 
   for (unsigned int i = 0; i < intervals.size(); i++) {
     for (unsigned int j = 0; j < intervals[i].intervals.size(); j++) {
-      // print the region information
+      /// print the region information
       outStream << intervals[i].chr << "\t" << intervals[i].intervals[j].start << "\t"
                 << intervals[i].intervals[j].end;
-      // print sample entropies for all files at that region
+      /// print sample entropies for all files at that region
       for (const auto &filename : filenames) {
         outStream << "\t" << sampens[filename].raw[i][j];
       }
@@ -43,11 +43,11 @@ void exportDetOut(const std::string &out, const std::vector<std::string> &filena
 }
 
 /**
- * Exports a .tsv file with sample entropies aggregated for every cell file
+ * Exports a tab separated file with sample entropies aggregated for every cell file.
  *
- * @param out path to .tsv file where sample entropy outputs are to be stored
- * @param filenames vector of filenames of all cell files
- * @param sampens SampEns object with detailed sample entropy data
+ * @param out path to tab separated file where sample entropy outputs are to be stored.
+ * @param filenames vector of filenames of all cell files.
+ * @param sampens SampEns object with detailed sample entropy data.
  */
 void exportOut(const std::string &out, const std::vector<std::string> &filenames,
                SampEns &sampens) {
@@ -59,7 +59,7 @@ void exportOut(const std::string &out, const std::vector<std::string> &filenames
   }
   outStream << "file\tvalue" << std::endl;
 
-  // print aggregated sample entropy for each file
+  /// print aggregated sample entropy for each file
   for (const auto &filename : filenames) {
     outStream << filename << "\t" << sampens[filename].agg;
     outStream << std::endl;

--- a/method/code/export.cpp
+++ b/method/code/export.cpp
@@ -1,33 +1,29 @@
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
 #include "chrData.h"
 #include "methData.h"
 #include "samp_en.h"
 
-void exportDetOut(const std::string &out, const std::vector<std::string> &filenames, SampEns &sampens, Intervals &intervals)
-{
+void exportDetOut(const std::string &out, const std::vector<std::string> &filenames,
+                  SampEns &sampens, Intervals &intervals) {
   std::ofstream outStream(out);
 
-  if (!outStream.is_open())
-  {
+  if (!outStream.is_open()) {
     std::cerr << "Error: Could not open file " << out << " for writing." << std::endl;
     return;
   }
   outStream << "chr\tstart\tend";
-  for (const auto &filename : filenames)
-  {
+  for (const auto &filename : filenames) {
     outStream << "\t" << filename;
   }
   outStream << std::endl;
 
-  for (unsigned int i = 0; i < intervals.size(); i++)
-  {
-    for (unsigned int j = 0; j < intervals[i].intervals.size(); j++)
-    {
-      outStream << intervals[i].chr << "\t" << intervals[i].intervals[j].start << "\t" << intervals[i].intervals[j].end;
-      for (const auto &filename : filenames)
-      {
+  for (unsigned int i = 0; i < intervals.size(); i++) {
+    for (unsigned int j = 0; j < intervals[i].intervals.size(); j++) {
+      outStream << intervals[i].chr << "\t" << intervals[i].intervals[j].start << "\t"
+                << intervals[i].intervals[j].end;
+      for (const auto &filename : filenames) {
         outStream << "\t" << sampens[filename].raw[i][j];
       }
       outStream << std::endl;
@@ -36,19 +32,17 @@ void exportDetOut(const std::string &out, const std::vector<std::string> &filena
   outStream.close();
 }
 
-void exportOut(const std::string &out, const std::vector<std::string> &filenames, SampEns &sampens)
-{
+void exportOut(const std::string &out, const std::vector<std::string> &filenames,
+               SampEns &sampens) {
   std::ofstream outStream(out);
 
-  if (!outStream.is_open())
-  {
+  if (!outStream.is_open()) {
     std::cerr << "Error: Could not open file " << out << " for writing." << std::endl;
     return;
   }
   outStream << "file\tvalue" << std::endl;
 
-  for (const auto &filename : filenames)
-  {
+  for (const auto &filename : filenames) {
     outStream << filename << "\t" << sampens[filename].agg;
     outStream << std::endl;
   }

--- a/method/code/export.cpp
+++ b/method/code/export.cpp
@@ -1,7 +1,10 @@
 #include <fstream>
 #include <iostream>
+#include <string>
+#include <vector>
 
 #include "chrData.h"
+#include "export.h"
 #include "methData.h"
 #include "samp_en.h"
 

--- a/method/code/filter.cpp
+++ b/method/code/filter.cpp
@@ -1,31 +1,27 @@
 #include <iostream>
-#include <zlib.h>
 #include <sstream>
+#include <zlib.h>
 
 #include "datarow.h"
 #include "filter.h"
 
-void filter(const std::string &filename, std::vector<DataRow> &data, const std::string &chr)
-{
+void filter(const std::string &filename, std::vector<DataRow> &data, const std::string &chr) {
   gzFile file = gzopen(filename.c_str(), "rb");
-  if (!file)
-  {
+  if (!file) {
     std::cerr << "Failed to open file: " << filename << std::endl;
     return;
   }
 
   constexpr int bufferSize = 32 * 1024;
-  char buffer[bufferSize];
-  std::string partialLine;
-  bool headerSkipped = false;
-  bool foundChr = false;
+  char          buffer[bufferSize];
+  std::string   partialLine;
+  bool          headerSkipped = false;
+  bool          foundChr      = false;
 
-  while (true)
-  {
+  while (true) {
     int bytesRead = gzread(file, buffer, bufferSize - 1);
 
-    if (bytesRead < 0)
-    {
+    if (bytesRead < 0) {
       std::cerr << "Error reading gzip file" << std::endl;
       gzclose(file);
       return;
@@ -37,36 +33,33 @@ void filter(const std::string &filename, std::vector<DataRow> &data, const std::
     partialLine.clear();
 
     std::istringstream ss(fullBuffer);
-    std::string line;
+    std::string        line;
 
-    while (std::getline(ss, line))
-    {
-      if (ss.eof() && line.back() != '\n')
-      {
+    while (std::getline(ss, line)) {
+      if (ss.eof() && line.back() != '\n') {
         partialLine = line;
         break;
       }
-      if (!headerSkipped)
-      {
+      if (!headerSkipped) {
         headerSkipped = true;
         continue;
       }
       std::istringstream lineStream(line);
-      DataRow row;
-      std::string temp;
+      DataRow            row;
+      std::string        temp;
       lineStream >> row.chr >> row.pos >> temp >> temp >> row.rate;
-      if (row.chr == chr)
-      {
+      if (row.chr == chr) {
         foundChr = true;
         data.push_back(row);
-      }
-      else if (foundChr)
+      } else if (foundChr) {
         break;
-      else
+      } else {
         continue;
+      }
     }
-    if (bytesRead < bufferSize - 1)
+    if (bytesRead < bufferSize - 1) {
       break;
+    }
   }
   gzclose(file);
 }

--- a/method/code/main.cpp
+++ b/method/code/main.cpp
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
       std::cout << std::endl;
     }
 
-    SampEns sampens = sampEn(fileMap, 2);
+    SampEns sampens = sampEn(fileMap, 2, getNStreams(vm));
     if (printSampens(vm)) {
       std::cout << "--Sample Entropies------------------" << std::endl << std::endl;
       for (const auto &file : fileMap) {
@@ -92,8 +92,14 @@ int main(int argc, char **argv) {
       exportOut(getOut(vm), filenames, sampens);
     }
     return 0;
-  } catch (const boost::program_options::error &e) {
+  } catch (const po::error &e) {
     std::cerr << e.what() << std::endl;
+    return 1;
+  } catch (const std::system_error &e) {
+    if (e.code().value() == 99) {
+      return 0;
+    }
+    std::cerr << "Error: " << e.what() << std::endl;
     return 1;
   } catch (const std::runtime_error &e) {
     std::cerr << "Error: " << e.what() << std::endl;

--- a/method/code/main.cpp
+++ b/method/code/main.cpp
@@ -1,56 +1,46 @@
 #include <iostream>
 
+#include "align.h"
 #include "boost.h"
 #include "chrData.h"
-#include "methData.h"
-#include "parse_search.h"
-#include "parse_ref.h"
-#include "align.h"
-#include "samp_en.h"
 #include "export.h"
+#include "methData.h"
+#include "parse_ref.h"
+#include "parse_search.h"
+#include "samp_en.h"
 // #include "filter.h"
 
-int main(int argc, char **argv)
-{
-  try
-  {
-    auto vm = parseCommandLine(argc, argv);
+int main(int argc, char **argv) {
+  try {
+    auto                     vm        = parseCommandLine(argc, argv);
     std::vector<std::string> filenames = getTsvFiles(vm);
 
-    std::cout << "--Search Regions------------------" << std::endl
-              << std::endl;
+    std::cout << "--Search Regions------------------" << std::endl << std::endl;
 
     Intervals intervals = parseSearch(getBed(vm));
-    for (const auto &[chr, intervals] : intervals)
-    {
+    for (const auto &[chr, intervals] : intervals) {
       std::cout << "Chromosome: " << chr << std::endl;
-      for (const auto &[start, end] : intervals)
-      {
+      for (const auto &[start, end] : intervals) {
         std::cout << "  Start: " << start << ", End: " << end << std::endl;
       }
     }
 
     std::cout << std::endl;
-    std::cout << "--Reference CPGs------------------" << std::endl
-              << std::endl;
+    std::cout << "--Reference CPGs------------------" << std::endl << std::endl;
 
     Reference ref = parseRef(getRef(vm), intervals);
-    // for (const auto &[chr, positions] : ref)
-    // {
-    //   std::cout << "Chromosome: " << chr << std::endl;
-    //   for (unsigned int binIndex = 0; binIndex < positions.size(); binIndex++)
-    //   {
-    //     std::cout << "  Bin: " << binIndex << std::endl;
-    //     for (const auto &pos : positions[binIndex])
-    //     {
-    //       std::cout << "    Pos: " << pos << std::endl;
-    //     }
-    //   }
-    // }
+    for (const auto &[chr, positions] : ref) {
+      std::cout << "Chromosome: " << chr << std::endl;
+      for (unsigned int binIndex = 0; binIndex < positions.size(); binIndex++) {
+        std::cout << "  Bin: " << binIndex << std::endl;
+        for (const auto &pos : positions[binIndex]) {
+          std::cout << "    Pos: " << pos << std::endl;
+        }
+      }
+    }
 
     std::cout << std::endl;
-    std::cout << "--Cell Files------------------" << std::endl
-              << std::endl;
+    std::cout << "--Cell Files------------------" << std::endl << std::endl;
 
     FileMap fileMap = alignWithRef(filenames, ref);
     // for (const auto &filename : filenames)
@@ -59,10 +49,12 @@ int main(int argc, char **argv)
     //   for (unsigned int chrIndex = 0; chrIndex < fileMap[filename].size(); chrIndex++)
     //   {
     //     std::cout << "  Chromosome: " << fileMap[filename][chrIndex].chr << std::endl;
-    //     for (unsigned int binIndex = 0; binIndex < fileMap[filename][chrIndex].meth.size(); binIndex++)
+    //     for (unsigned int binIndex = 0; binIndex < fileMap[filename][chrIndex].meth.size();
+    //     binIndex++)
     //     {
-    //       std::cout << "    Bin: " << binIndex << ", size: " << fileMap[filename][chrIndex].meth[binIndex].size() << std::endl;
-    //       for (const auto &methValue : fileMap[filename][chrIndex].meth[binIndex])
+    //       std::cout << "    Bin: " << binIndex << ", size: " <<
+    //       fileMap[filename][chrIndex].meth[binIndex].size() << std::endl; for (const auto
+    //       &methValue : fileMap[filename][chrIndex].meth[binIndex])
     //       {
     //         std::cout << "      Meth: " << methValue << std::endl;
     //       }
@@ -72,41 +64,35 @@ int main(int argc, char **argv)
     // }
 
     std::cout << std::endl;
-    std::cout << "--Sample Entropies------------------" << std::endl
-              << std::endl;
+    std::cout << "--Sample Entropies------------------" << std::endl << std::endl;
 
     SampEns sampens = sampEn(fileMap, 2);
-    for (const auto &file : fileMap)
-    {
+    for (const auto &file : fileMap) {
       std::cout << "Filename: " << file.first << std::endl;
       std::cout << "  Aggregate: " << sampens[file.first].agg << std::endl;
       std::cout << "  Detailed:" << std::endl;
-      for (unsigned int chrIndex = 0; chrIndex < sampens[file.first].raw.size(); chrIndex++)
-      {
+      for (unsigned int chrIndex = 0; chrIndex < sampens[file.first].raw.size(); chrIndex++) {
         std::cout << "    Chromosome: " << file.second[chrIndex].chr << std::endl;
-        for (unsigned int binIndex = 0; binIndex < sampens[file.first].raw[chrIndex].size(); binIndex++)
-        {
-          std::cout << "      Bin " << binIndex << " -> " << sampens[file.first].raw[chrIndex][binIndex] << std::endl;
+        for (unsigned int binIndex = 0; binIndex < sampens[file.first].raw[chrIndex].size();
+             binIndex++) {
+          std::cout << "      Bin " << binIndex << " -> "
+                    << sampens[file.first].raw[chrIndex][binIndex] << std::endl;
         }
       }
       std::cout << std::endl;
     }
 
-    if (vm.count("det-out"))
-    {
+    if (vm.count("det-out")) {
       exportDetOut(getDetOut(vm), filenames, sampens, intervals);
     }
-    if (vm.count("out"))
-    {
+    if (vm.count("out")) {
       exportOut(getOut(vm), filenames, sampens);
     }
     // filter(filenames[0], data, getChr(vm));
     // const DataRow &firstRow = data[0]; // Access the first element
     // std::cout << sampEn(data, 2) << std::endl;
     return 0;
-  }
-  catch (const std::runtime_error &e)
-  {
+  } catch (const std::runtime_error &e) {
     return 0;
   }
 }

--- a/method/code/main.cpp
+++ b/method/code/main.cpp
@@ -56,7 +56,8 @@ int main(int argc, char **argv) {
                       << ", size: " << fileMap[filename][chrIndex].meth[binIndex].size()
                       << std::endl;
             for (const auto &methValue : fileMap[filename][chrIndex].meth[binIndex]) {
-              std::cout << "      Meth: " << methValue << std::endl;
+              std::cout << "      Meth: " << (methValue == -1 ? '?' : (char)(methValue + '0'))
+                        << std::endl;
             }
           }
         }

--- a/method/code/main.cpp
+++ b/method/code/main.cpp
@@ -12,11 +12,11 @@
 
 int main(int argc, char **argv) {
   try {
-    auto                     vm        = parseCommandLine(argc, argv);
+    auto vm = parseCommandLine(argc, argv);
+
     std::vector<std::string> filenames = getTsvFiles(vm);
 
     Intervals intervals = parseSearch(getBed(vm));
-
     if (vm.count("print-bed")) {
       std::cout << "--Search Regions------------------" << std::endl << std::endl;
       for (const auto &[chr, intervals] : intervals) {
@@ -29,7 +29,6 @@ int main(int argc, char **argv) {
     }
 
     Reference ref = parseRef(getRef(vm), intervals);
-
     if (vm.count("print-ref")) {
       std::cout << "--Reference CPGs------------------" << std::endl << std::endl;
       for (const auto &[chr, positions] : ref) {
@@ -45,7 +44,6 @@ int main(int argc, char **argv) {
     }
 
     FileMap fileMap = alignWithRef(filenames, ref);
-
     if (vm.count("print-tsv")) {
       std::cout << "--Cell Files------------------" << std::endl << std::endl;
       for (const auto &filename : filenames) {
@@ -68,7 +66,6 @@ int main(int argc, char **argv) {
     }
 
     SampEns sampens = sampEn(fileMap, 2);
-
     if (printSampens(vm)) {
       std::cout << "--Sample Entropies------------------" << std::endl << std::endl;
       for (const auto &file : fileMap) {

--- a/method/code/main.cpp
+++ b/method/code/main.cpp
@@ -44,30 +44,29 @@ int main(int argc, char **argv) {
       std::cout << std::endl;
     }
 
-    std::cout << "--Cell Files------------------" << std::endl << std::endl;
-
     FileMap fileMap = alignWithRef(filenames, ref);
-    // for (const auto &filename : filenames)
-    // {
-    //   std::cout << "Filename: " << filename << std::endl;
-    //   for (unsigned int chrIndex = 0; chrIndex < fileMap[filename].size(); chrIndex++)
-    //   {
-    //     std::cout << "  Chromosome: " << fileMap[filename][chrIndex].chr << std::endl;
-    //     for (unsigned int binIndex = 0; binIndex < fileMap[filename][chrIndex].meth.size();
-    //     binIndex++)
-    //     {
-    //       std::cout << "    Bin: " << binIndex << ", size: " <<
-    //       fileMap[filename][chrIndex].meth[binIndex].size() << std::endl; for (const auto
-    //       &methValue : fileMap[filename][chrIndex].meth[binIndex])
-    //       {
-    //         std::cout << "      Meth: " << methValue << std::endl;
-    //       }
-    //     }
-    //   }
-    //   std::cout << std::endl;
-    // }
 
-    std::cout << std::endl;
+    if (vm.count("print-tsv")) {
+      std::cout << "--Cell Files------------------" << std::endl << std::endl;
+      for (const auto &filename : filenames) {
+        std::cout << "Filename: " << filename << std::endl;
+        for (unsigned int chrIndex = 0; chrIndex < fileMap[filename].size(); chrIndex++) {
+          std::cout << "  Chromosome: " << fileMap[filename][chrIndex].chr << std::endl;
+          for (unsigned int binIndex = 0; binIndex < fileMap[filename][chrIndex].meth.size();
+               binIndex++) {
+            std::cout << "    Bin: " << binIndex
+                      << ", size: " << fileMap[filename][chrIndex].meth[binIndex].size()
+                      << std::endl;
+            for (const auto &methValue : fileMap[filename][chrIndex].meth[binIndex]) {
+              std::cout << "      Meth: " << methValue << std::endl;
+            }
+          }
+        }
+        std::cout << std::endl;
+      }
+      std::cout << std::endl;
+    }
+
     std::cout << "--Sample Entropies------------------" << std::endl << std::endl;
 
     SampEns sampens = sampEn(fileMap, 2);

--- a/method/code/main.cpp
+++ b/method/code/main.cpp
@@ -15,31 +15,35 @@ int main(int argc, char **argv) {
     auto                     vm        = parseCommandLine(argc, argv);
     std::vector<std::string> filenames = getTsvFiles(vm);
 
-    std::cout << "--Search Regions------------------" << std::endl << std::endl;
-
     Intervals intervals = parseSearch(getBed(vm));
-    for (const auto &[chr, intervals] : intervals) {
-      std::cout << "Chromosome: " << chr << std::endl;
-      for (const auto &[start, end] : intervals) {
-        std::cout << "  Start: " << start << ", End: " << end << std::endl;
-      }
-    }
 
-    std::cout << std::endl;
-    std::cout << "--Reference CPGs------------------" << std::endl << std::endl;
-
-    Reference ref = parseRef(getRef(vm), intervals);
-    for (const auto &[chr, positions] : ref) {
-      std::cout << "Chromosome: " << chr << std::endl;
-      for (unsigned int binIndex = 0; binIndex < positions.size(); binIndex++) {
-        std::cout << "  Bin: " << binIndex << std::endl;
-        for (const auto &pos : positions[binIndex]) {
-          std::cout << "    Pos: " << pos << std::endl;
+    if (vm.count("print-bed")) {
+      std::cout << "--Search Regions------------------" << std::endl << std::endl;
+      for (const auto &[chr, intervals] : intervals) {
+        std::cout << "Chromosome: " << chr << std::endl;
+        for (const auto &[start, end] : intervals) {
+          std::cout << "  Start: " << start << ", End: " << end << std::endl;
         }
       }
+      std::cout << std::endl;
     }
 
-    std::cout << std::endl;
+    Reference ref = parseRef(getRef(vm), intervals);
+
+    if (vm.count("print-ref")) {
+      std::cout << "--Reference CPGs------------------" << std::endl << std::endl;
+      for (const auto &[chr, positions] : ref) {
+        std::cout << "Chromosome: " << chr << std::endl;
+        for (unsigned int binIndex = 0; binIndex < positions.size(); binIndex++) {
+          std::cout << "  Bin: " << binIndex << std::endl;
+          for (const auto &pos : positions[binIndex]) {
+            std::cout << "    Pos: " << pos << std::endl;
+          }
+        }
+      }
+      std::cout << std::endl;
+    }
+
     std::cout << "--Cell Files------------------" << std::endl << std::endl;
 
     FileMap fileMap = alignWithRef(filenames, ref);

--- a/method/code/main.cpp
+++ b/method/code/main.cpp
@@ -67,22 +67,24 @@ int main(int argc, char **argv) {
       std::cout << std::endl;
     }
 
-    std::cout << "--Sample Entropies------------------" << std::endl << std::endl;
-
     SampEns sampens = sampEn(fileMap, 2);
-    for (const auto &file : fileMap) {
-      std::cout << "Filename: " << file.first << std::endl;
-      std::cout << "  Aggregate: " << sampens[file.first].agg << std::endl;
-      std::cout << "  Detailed:" << std::endl;
-      for (unsigned int chrIndex = 0; chrIndex < sampens[file.first].raw.size(); chrIndex++) {
-        std::cout << "    Chromosome: " << file.second[chrIndex].chr << std::endl;
-        for (unsigned int binIndex = 0; binIndex < sampens[file.first].raw[chrIndex].size();
-             binIndex++) {
-          std::cout << "      Bin " << binIndex << " -> "
-                    << sampens[file.first].raw[chrIndex][binIndex] << std::endl;
+
+    if (printSampens(vm)) {
+      std::cout << "--Sample Entropies------------------" << std::endl << std::endl;
+      for (const auto &file : fileMap) {
+        std::cout << "Filename: " << file.first << std::endl;
+        std::cout << "  Aggregate: " << sampens[file.first].agg << std::endl;
+        std::cout << "  Detailed:" << std::endl;
+        for (unsigned int chrIndex = 0; chrIndex < sampens[file.first].raw.size(); chrIndex++) {
+          std::cout << "    Chromosome: " << file.second[chrIndex].chr << std::endl;
+          for (unsigned int binIndex = 0; binIndex < sampens[file.first].raw[chrIndex].size();
+               binIndex++) {
+            std::cout << "      Bin " << binIndex << " -> "
+                      << sampens[file.first].raw[chrIndex][binIndex] << std::endl;
+          }
         }
+        std::cout << std::endl;
       }
-      std::cout << std::endl;
     }
 
     if (vm.count("det-out")) {
@@ -91,9 +93,6 @@ int main(int argc, char **argv) {
     if (vm.count("out")) {
       exportOut(getOut(vm), filenames, sampens);
     }
-    // filter(filenames[0], data, getChr(vm));
-    // const DataRow &firstRow = data[0]; // Access the first element
-    // std::cout << sampEn(data, 2) << std::endl;
     return 0;
   } catch (const std::runtime_error &e) {
     return 0;

--- a/method/code/main.cpp
+++ b/method/code/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
       std::cout << std::endl;
     }
 
-    FileMap fileMap = alignWithRef(filenames, ref);
+    FileMap fileMap = alignWithRef(filenames, ref, getNCores(vm), getNThreadsPerCore(vm));
     if (vm.count("print-tsv")) {
       std::cout << "--Cell Files------------------" << std::endl << std::endl;
       for (const auto &filename : filenames) {
@@ -92,7 +92,11 @@ int main(int argc, char **argv) {
       exportOut(getOut(vm), filenames, sampens);
     }
     return 0;
+  } catch (const boost::program_options::error &e) {
+    std::cerr << e.what() << std::endl;
+    return 1;
   } catch (const std::runtime_error &e) {
-    return 0;
+    std::cerr << "Error: " << e.what() << std::endl;
+    return 1;
   }
 }

--- a/method/code/parse_ref.cpp
+++ b/method/code/parse_ref.cpp
@@ -1,8 +1,11 @@
 #include <iostream>
 #include <sstream>
+#include <string>
+#include <vector>
 #include <zlib.h>
 
 #include "chrData.h"
+#include "parse_ref.h"
 
 /**
  * Parse a tab separated file of all positions of a reference genome into a nested structure
@@ -25,7 +28,7 @@ Reference parseRef(const std::string &filename, Intervals intervals) {
    */
   Reference ref;
   for (const auto &[chr, intervals] : intervals) {
-    ref.emplace_back(chr, std::vector<std::vector<unsigned int>>(intervals.size()));
+    ref.emplace_back(chr, intervals.size());
   }
 
   /**

--- a/method/code/parse_ref.cpp
+++ b/method/code/parse_ref.cpp
@@ -121,7 +121,7 @@ Reference parseRef(const std::string &filename, Intervals intervals) {
         ref[chrIndex].positions[intervalIndex].emplace_back(pos);
       }
     }
-    if (bytesRead < bufferSize - 1 && partialLine.empty()) {
+    if (bytesRead < bufferSize - 1) {
       break;
     }
   }

--- a/method/code/parse_ref.cpp
+++ b/method/code/parse_ref.cpp
@@ -1,45 +1,44 @@
 #include <iostream>
-#include <zlib.h>
 #include <sstream>
+#include <zlib.h>
 
 #include "chrData.h"
 
 /**
- * Parse a bed.gz file of all CpGs of a reference genome into a nested structure to be used for aligning the relevant regions of different cell files.
+ * Parse a bed.gz file of all CpGs of a reference genome into a nested structure
+ * to be used for aligning the relevant regions of different cell files.
  *
  * @param filename path to bed.gz file to be extracted.
  * @param intervals Intervals object with search intervals.
- * @return Reference object which contain the chr information and intervals corresponding to it.
+ * @return Reference object which contain the chr information and intervals
+ * corresponding to it.
  */
-Reference parseRef(const std::string &filename, Intervals intervals)
-{
+Reference parseRef(const std::string &filename, Intervals intervals) {
   gzFile file = gzopen(filename.c_str(), "rb");
-  if (!file)
-  {
+  if (!file) {
     std::cerr << "Failed to open file: " << filename << std::endl;
   }
 
   Reference ref;
-  for (const auto &[chr, intervals] : intervals)
-  {
+  for (const auto &[chr, intervals] : intervals) {
     ref.emplace_back(chr, std::vector<std::vector<unsigned int>>(intervals.size()));
   }
 
   constexpr int bufferSize = 64 * 1024;
-  char buffer[bufferSize];
-  std::string partialLine;
-  bool firstFound = false;
+  char          buffer[bufferSize];
+  std::string   partialLine;
+  std::string   currentChr = "";
+  bool          firstFound = false;
   // bool headerSkipped = false;
 
-  unsigned int chrIndex = 0, intervalIndex = 0;
-  bool done = false;
+  int          chrIndex      = -1;
+  unsigned int intervalIndex = 0;
+  bool         done          = false;
 
-  while (!done)
-  {
+  while (!done) {
     int bytesRead = gzread(file, buffer, bufferSize - 1);
 
-    if (bytesRead < 0)
-    {
+    if (bytesRead < 0) {
       std::cerr << "Error reading gzip file" << std::endl;
       gzclose(file);
     }
@@ -50,12 +49,10 @@ Reference parseRef(const std::string &filename, Intervals intervals)
     partialLine.clear();
 
     std::istringstream ss(fullBuffer);
-    std::string line;
+    std::string        line;
 
-    while (std::getline(ss, line))
-    {
-      if (ss.eof() && line.back() != '\n')
-      {
+    while (std::getline(ss, line)) {
+      if (ss.eof() && line.back() != '\n') {
         partialLine = line;
         break;
       }
@@ -65,84 +62,49 @@ Reference parseRef(const std::string &filename, Intervals intervals)
       //   continue;
       // }
       std::istringstream lineStream(line);
-      std::string chr, temp;
-      unsigned int pos;
+      std::string        chr, temp;
+      unsigned int       pos;
       lineStream >> chr >> pos >> temp;
-      // std::cout << chr << " " << pos << std::endl;
-      // std::cout << chrIndex << " " << intervalIndex << std::endl;
+      std::cout << "chr: " << chr << "| pos: " << pos << std::endl;
 
-      if (chr != intervals[chrIndex].chr)
-        if (firstFound)
-        {
-          if (chrIndex < intervals.size() - 1)
-          {
-            chrIndex++;
-            intervalIndex = 0;
-          }
-        }
-        else
-        {
+      if (chr != currentChr) {
+        currentChr = chr;
+        firstFound = false;
+      }
+
+      if (chrIndex < (int)(intervals.size() - 1)) {
+        if (chr == intervals[chrIndex + 1].chr) {
+          chrIndex++;
+          intervalIndex = 0;
+          firstFound    = true;
+        } else if (!firstFound) {
           continue;
         }
-      firstFound = true;
-      if (pos < intervals[chrIndex].intervals[intervalIndex].start)
+      } else if (chr != intervals[chrIndex].chr) {
+        done = true;
+        break;
+      }
+
+      if (pos < intervals[chrIndex].intervals[intervalIndex].start) {
         continue;
-      while (intervals[chrIndex].intervals[intervalIndex].end <= pos)
-      {
-        if (intervalIndex < intervals[chrIndex].intervals.size() - 1)
-        {
+      }
+      while (intervals[chrIndex].intervals[intervalIndex].end <= pos) {
+        if (intervalIndex < intervals[chrIndex].intervals.size() - 1) {
           intervalIndex++;
-        }
-        else
-        {
-          if (chrIndex < intervals.size() - 1)
-          {
-            chrIndex++;
-            intervalIndex = 0;
-          }
+        } else {
           break;
         }
       }
 
-      // if (pos < intervals[chrIndex].intervals[intervalIndex].start)
-      //   continue;
-      // while (intervals[chrIndex].intervals[intervalIndex].end <= pos)
-      // {
-      //   if (chrIndex == intervals.size() - 1)
-      //   {
-      //     if (intervalIndex == intervals[chrIndex].intervals.size() - 1)
-      //     {
-      //       done = true;
-      //       break;
-      //     }
-      //     intervalIndex++;
-      //   }
-      //   else
-      //   {
-      //     if (intervalIndex == intervals[chrIndex].intervals.size() - 1)
-      //     {
-      //       chrIndex++;
-      //       intervalIndex = 0;
-      //       break;
-      //     }
-      //     else
-      //     {
-      //       intervalIndex++;
-      //     }
-      //   }
-      // }
-
-      // if (done)
-      //   break;
-      if (chr == intervals[chrIndex].chr && intervals[chrIndex].intervals[intervalIndex].start <= pos && pos < intervals[chrIndex].intervals[intervalIndex].end)
-      {
+      if (chr == intervals[chrIndex].chr &&
+          intervals[chrIndex].intervals[intervalIndex].start <= pos &&
+          pos < intervals[chrIndex].intervals[intervalIndex].end) {
         ref[chrIndex].positions[intervalIndex].emplace_back(pos);
       }
     }
-    // if (done)
-    //   break;
-    if (bytesRead < bufferSize - 1)
+    if (bytesRead < bufferSize - 1) {
       break;
+    }
   }
   return ref;
 }

--- a/method/code/parse_ref.cpp
+++ b/method/code/parse_ref.cpp
@@ -65,7 +65,6 @@ Reference parseRef(const std::string &filename, Intervals intervals) {
       std::string        chr, temp;
       unsigned int       pos;
       lineStream >> chr >> pos >> temp;
-      std::cout << "chr: " << chr << "| pos: " << pos << std::endl;
 
       if (chr != currentChr) {
         currentChr = chr;

--- a/method/code/parse_ref.cpp
+++ b/method/code/parse_ref.cpp
@@ -70,8 +70,7 @@ Reference parseRef(const std::string &filename, Intervals intervals) {
         partialLine = line;
         break;
       }
-      // if (!headerSkipped)
-      // {
+      // if (!headerSkipped) {
       //   headerSkipped = true;
       //   continue;
       // }

--- a/method/code/parse_ref.cpp
+++ b/method/code/parse_ref.cpp
@@ -5,7 +5,7 @@
 #include "chrData.h"
 
 /**
- * Parse a bed.gz file of all CpGs of a reference genome into a nested structure
+ * Parse a tab separated file of all positions of a reference genome into a nested structure
  * to be used for aligning the relevant regions of different cell files.
  *
  * @param filename path to bed.gz file to be extracted.
@@ -19,22 +19,26 @@ Reference parseRef(const std::string &filename, Intervals intervals) {
     std::cerr << "Failed to open file: " << filename << std::endl;
   }
 
-  /* create output reference variable and initialise accordingly with chromosomes where search
-   * regions are present */
+  /**
+   *  create output reference variable and initialise accordingly with chromosomes where search
+   * regions are present
+   */
   Reference ref;
   for (const auto &[chr, intervals] : intervals) {
     ref.emplace_back(chr, std::vector<std::vector<unsigned int>>(intervals.size()));
   }
 
-  /* buffer size of 64M - this is the total amount of information from a file stored at any time as
-   * a chunk */
+  /**
+   * buffer size of 64M - this is the total amount of information from a file stored at any time as
+   * a chunk
+   */
   constexpr int bufferSize = 64 * 1024;
   char          buffer[bufferSize];
   std::string   partialLine;
 
-  // current chromosome being parsed from reference file
+  /// current chromosome being parsed from reference file
   std::string currentChr = "";
-  // indicates whether there is a region requested for a particular chromosome
+  /// indicates whether there is a region requested for a particular chromosome
   bool firstFound = false;
   // bool headerSkipped = false;
 
@@ -43,7 +47,7 @@ Reference parseRef(const std::string &filename, Intervals intervals) {
   bool         done          = false;
 
   while (!done) {
-    // read a chunk of data from a file
+    /// read a chunk of data from a file
     int bytesRead = gzread(file, buffer, bufferSize - 1);
 
     if (bytesRead < 0) {
@@ -59,9 +63,9 @@ Reference parseRef(const std::string &filename, Intervals intervals) {
     std::istringstream ss(fullBuffer);
     std::string        line;
 
-    // iterate over lines in a chunk
+    /// iterate over lines in a chunk
     while (std::getline(ss, line)) {
-      // save partial line to be processed later
+      /// save partial line to be processed later
       if (ss.eof() && line.back() != '\n') {
         partialLine = line;
         break;
@@ -72,20 +76,22 @@ Reference parseRef(const std::string &filename, Intervals intervals) {
       //   continue;
       // }
 
-      // parsing a line from reference
+      /// parsing a line from reference
       std::istringstream lineStream(line);
       std::string        chr, temp;
       unsigned int       pos;
       lineStream >> chr >> pos >> temp;
 
-      // updates chromosome currently being evaluated and resets firstFound
+      /// updates chromosome currently being evaluated and resets firstFound
       if (chr != currentChr) {
         currentChr = chr;
         firstFound = false;
       }
 
-      /* once done with all positions in a chromosome, move to next chromosome with regions of
-       * interest, ignoring chromosomes in between */
+      /**
+       * once done with all positions in a chromosome, move to next chromosome with regions of
+       * interest, ignoring chromosomes in between
+       */
       if (chrIndex < (int)(intervals.size() - 1)) {
         if (chr == intervals[chrIndex + 1].chr) {
           chrIndex++;
@@ -99,13 +105,15 @@ Reference parseRef(const std::string &filename, Intervals intervals) {
         break;
       }
 
-      // discard positions outside regions of interest
+      /// discard positions outside regions of interest
       if (pos < intervals[chrIndex].intervals[intervalIndex].start) {
         continue;
       }
 
-      /* for a particular postion, finds the closest region on the chromosome (if it exists)
-       * enclosing or before the position */
+      /**
+       * for a particular postion, finds the closest region on the chromosome (if it exists)
+       * enclosing or before the position
+       */
       while (intervals[chrIndex].intervals[intervalIndex].end <= pos) {
         if (intervalIndex < intervals[chrIndex].intervals.size() - 1) {
           intervalIndex++;
@@ -114,7 +122,7 @@ Reference parseRef(const std::string &filename, Intervals intervals) {
         }
       }
 
-      // add valid position to output reference variable
+      /// add valid position to output reference variable
       if (chr == intervals[chrIndex].chr &&
           intervals[chrIndex].intervals[intervalIndex].start <= pos &&
           pos < intervals[chrIndex].intervals[intervalIndex].end) {

--- a/method/code/parse_search.cpp
+++ b/method/code/parse_search.cpp
@@ -25,6 +25,7 @@ std::vector<ChrIntervals> parseSearch(const std::string &filename) {
   std::vector<Position> currentIntervals;
 
   while (std::getline(bedFile, line)) {
+    // parsing a line from regions file
     std::istringstream iss(line);
     std::string        chr;
     unsigned int       start, end;

--- a/method/code/parse_search.cpp
+++ b/method/code/parse_search.cpp
@@ -2,8 +2,11 @@
 #include <iostream>
 #include <list>
 #include <sstream>
+#include <string>
+#include <vector>
 
 #include "chrData.h"
+#include "parse_search.h"
 
 /**
  * Parse a bed file of search intervals into a nested structure to be used for extracting the
@@ -23,7 +26,7 @@ Intervals parseSearch(const std::string &filename) {
 
   std::string           line;
   std::string           currentChr = "";
-  std::vector<Position> currentIntervals;
+  std::vector<Interval> currentIntervals;
 
   while (std::getline(bedFile, line)) {
     /// parsing a line from regions file

--- a/method/code/parse_search.cpp
+++ b/method/code/parse_search.cpp
@@ -7,25 +7,26 @@
 
 /**
  * Parse a bed file of search intervals into a nested structure to be used for extracting the
- * relevant regions of the reference.
+ * relevant regions of the reference. We require that all search regions in a chromosome be disjoint
+ * from one another.
  *
  * @param filename path to bed file to be extracted.
  * @return vector of structs which contain the chr information and intervals corresponding to it.
  */
-std::vector<ChrIntervals> parseSearch(const std::string &filename) {
+Intervals parseSearch(const std::string &filename) {
   std::ifstream bedFile(filename);
   if (!bedFile.is_open()) {
     std::cerr << "Error: Could not open file " << filename << std::endl;
   }
 
-  std::vector<ChrIntervals> intervals;
+  Intervals intervals;
 
   std::string           line;
   std::string           currentChr = "";
   std::vector<Position> currentIntervals;
 
   while (std::getline(bedFile, line)) {
-    // parsing a line from regions file
+    /// parsing a line from regions file
     std::istringstream iss(line);
     std::string        chr;
     unsigned int       start, end;

--- a/method/code/parse_search.cpp
+++ b/method/code/parse_search.cpp
@@ -1,41 +1,37 @@
-#include <iostream>
 #include <fstream>
-#include <sstream>
+#include <iostream>
 #include <list>
+#include <sstream>
 
 #include "chrData.h"
 
 /**
- * Parse a bed file of search intervals into a nested structure to be used for extracting the relevant regions of the reference.
+ * Parse a bed file of search intervals into a nested structure to be used for extracting the
+ * relevant regions of the reference.
  *
  * @param filename path to bed file to be extracted.
  * @return vector of structs which contain the chr information and intervals corresponding to it.
  */
-std::vector<ChrIntervals> parseSearch(const std::string &filename)
-{
+std::vector<ChrIntervals> parseSearch(const std::string &filename) {
   std::ifstream bedFile(filename);
-  if (!bedFile.is_open())
-  {
+  if (!bedFile.is_open()) {
     std::cerr << "Error: Could not open file " << filename << std::endl;
   }
 
   std::vector<ChrIntervals> intervals;
 
-  std::string line;
-  std::string currentChr = "";
+  std::string           line;
+  std::string           currentChr = "";
   std::vector<Position> currentIntervals;
 
-  while (std::getline(bedFile, line))
-  {
+  while (std::getline(bedFile, line)) {
     std::istringstream iss(line);
-    std::string chr;
-    unsigned int start, end;
+    std::string        chr;
+    unsigned int       start, end;
     iss >> chr >> start >> end;
 
-    if (chr != currentChr)
-    {
-      if (!currentIntervals.empty())
-      {
+    if (chr != currentChr) {
+      if (!currentIntervals.empty()) {
         intervals.emplace_back(currentChr, currentIntervals);
         currentIntervals.clear();
       }
@@ -44,8 +40,7 @@ std::vector<ChrIntervals> parseSearch(const std::string &filename)
     currentIntervals.emplace_back(start, end);
   }
 
-  if (!currentIntervals.empty())
-  {
+  if (!currentIntervals.empty()) {
     intervals.emplace_back(currentChr, currentIntervals);
   }
 

--- a/method/code/samp_en.cu
+++ b/method/code/samp_en.cu
@@ -1,159 +1,157 @@
-#include <iostream>
-#include <vector>
 #include <array>
 #include <cuda_runtime.h>
+#include <iostream>
+#include <vector>
 
 #include "methData.h"
 #include "samp_en.h"
 
-__global__ void templateMatcher(char *data, const unsigned int cumulativeSize, const unsigned int m, unsigned int *d_prefixSum, const unsigned int numBins, unsigned int *cm, unsigned int *cm_1)
-{
+__global__ void templateMatcher(char *data, const unsigned int cumulativeSize, const unsigned int m,
+                                unsigned int *d_prefixSum, const unsigned int numBins,
+                                unsigned int *cm, unsigned int *cm_1) {
   unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
   unsigned int j = blockIdx.y * blockDim.y + threadIdx.y;
 
   if (j > cumulativeSize - m || i >= j || numBins == 0)
     return;
-  unsigned int low = 0;
+  unsigned int low  = 0;
   unsigned int high = numBins - 1;
   unsigned int mid;
-  int binIndex = -1;
+  int          binIndex = -1;
 
-  while (low <= high)
-  {
+  while (low <= high) {
     mid = low + (high - low) / 2;
-    if (d_prefixSum[mid] == j)
-    {
+    if (d_prefixSum[mid] == j) {
       binIndex = mid;
       break;
-    }
-    else if (d_prefixSum[mid] < j)
-    {
+    } else if (d_prefixSum[mid] < j) {
       binIndex = mid;
-      low = mid + 1;
-    }
-    else
-    {
+      low      = mid + 1;
+    } else {
       high = mid - 1;
     }
   }
-  unsigned int binEnd = (binIndex == numBins - 1) ? cumulativeSize : d_prefixSum[binIndex + 1];
+  unsigned int binEnd  = (binIndex == numBins - 1) ? cumulativeSize : d_prefixSum[binIndex + 1];
   unsigned int binSize = binEnd - d_prefixSum[binIndex];
-  unsigned int j_rel = j - d_prefixSum[binIndex];
+  unsigned int j_rel   = j - d_prefixSum[binIndex];
 
   if (i < d_prefixSum[binIndex] || j_rel >= binSize - m)
     return;
 
   bool eq = true;
-  for (unsigned int k = 0; k < m; k++)
-  {
-    if (data[i + k] == -1 || data[j + k] == -1 || data[i + k] != data[j + k])
-    {
+  for (unsigned int k = 0; k < m; k++) {
+    if (data[i + k] == -1 || data[j + k] == -1 || data[i + k] != data[j + k]) {
       eq = false;
       break;
     }
   }
-  if (eq && data[i + m] != -1 && data[j + m] != -1)
-  {
+  if (eq && data[i + m] != -1 && data[j + m] != -1) {
     atomicAdd(&cm[binIndex], 1);
     if (data[i + m] == data[j + m])
       atomicAdd(&cm_1[binIndex], 1);
   }
 }
 
-SampEns sampEn(FileMap &fileMap, const unsigned int m)
-{
+SampEns sampEn(FileMap &fileMap, const unsigned int m) {
   SampEns sampens;
-  Counts counts;
-  for (const auto &[file, fileMeths] : fileMap)
-  {
+  Counts  counts;
+  for (const auto &[file, fileMeths] : fileMap) {
     std::vector<std::vector<double>> x;
     for (const auto &chrBins : fileMeths)
       x.emplace_back(std::vector<double>(chrBins.meth.size(), -1.0));
     sampens[file] = FileSampEns{std::move(x), -1.0};
-    counts[file] = FileCounts{0, 0};
+    counts[file]  = FileCounts{0, 0};
   }
 
   unsigned short num_streams = 50;
 
   // create CUDA streams
   cudaStream_t streams[num_streams];
-  for (unsigned short i = 0; i < num_streams; ++i)
-  {
+  for (unsigned short i = 0; i < num_streams; ++i) {
     cudaStreamCreate(&streams[i]);
   }
 
-  char *d_flatBins[num_streams];
-  unsigned int *d_cm[num_streams];
-  unsigned int *d_cm_1[num_streams];
-  unsigned int *d_prefix_sum[num_streams];
-  std::vector<unsigned int> goodBins[num_streams] = {};
-  unsigned int cumulativeSize[num_streams] = {0};
-  std::pair<std::string, unsigned int> streamInfo[num_streams] = {{"", 0}};
+  char                                *d_flatBins[num_streams];
+  unsigned int                        *d_cm[num_streams];
+  unsigned int                        *d_cm_1[num_streams];
+  unsigned int                        *d_prefix_sum[num_streams];
+  std::vector<unsigned int>            goodBins[num_streams]       = {};
+  unsigned int                         cumulativeSize[num_streams] = {0};
+  std::pair<std::string, unsigned int> streamInfo[num_streams]     = {{"", 0}};
 
-  unsigned int fileIndex = 0;
+  unsigned int   fileIndex = 0;
   unsigned short streamIdx = 0;
 
-  for (const auto &[file, fileMeths] : fileMap)
-  {
-    for (unsigned int chrIndex = 0; chrIndex < fileMeths.size(); chrIndex++)
-    {
+  for (const auto &[file, fileMeths] : fileMap) {
+    for (unsigned int chrIndex = 0; chrIndex < fileMeths.size(); chrIndex++) {
       streamInfo[streamIdx] = {file, chrIndex};
       std::vector<unsigned int> prefix_sum;
-      for (unsigned int i = 0; i < fileMeths[chrIndex].meth.size(); i++)
-      {
-        if (!fileMeths[chrIndex].meth[i].empty())
-        {
+      for (unsigned int i = 0; i < fileMeths[chrIndex].meth.size(); i++) {
+        if (!fileMeths[chrIndex].meth[i].empty()) {
           goodBins[streamIdx].push_back(i);
           prefix_sum.push_back(cumulativeSize[streamIdx]);
           cumulativeSize[streamIdx] += fileMeths[chrIndex].meth[i].size();
         }
       }
 
-      cudaMallocAsync(&d_flatBins[streamIdx], cumulativeSize[streamIdx] * sizeof(char), streams[streamIdx]);
-      cudaMallocAsync(&d_prefix_sum[streamIdx], prefix_sum.size() * sizeof(unsigned int), streams[streamIdx]);
-      cudaMallocAsync(&d_cm[streamIdx], goodBins[streamIdx].size() * sizeof(unsigned int), streams[streamIdx]);
-      cudaMallocAsync(&d_cm_1[streamIdx], goodBins[streamIdx].size() * sizeof(unsigned int), streams[streamIdx]);
+      cudaMallocAsync(&d_flatBins[streamIdx], cumulativeSize[streamIdx] * sizeof(char),
+                      streams[streamIdx]);
+      cudaMallocAsync(&d_prefix_sum[streamIdx], prefix_sum.size() * sizeof(unsigned int),
+                      streams[streamIdx]);
+      cudaMallocAsync(&d_cm[streamIdx], goodBins[streamIdx].size() * sizeof(unsigned int),
+                      streams[streamIdx]);
+      cudaMallocAsync(&d_cm_1[streamIdx], goodBins[streamIdx].size() * sizeof(unsigned int),
+                      streams[streamIdx]);
 
-      for (unsigned int i = 0; i < goodBins[streamIdx].size(); i++)
-      {
+      for (unsigned int i = 0; i < goodBins[streamIdx].size(); i++) {
         unsigned int rowIndex = goodBins[streamIdx][i];
-        cudaMemcpyAsync(d_flatBins[streamIdx] + prefix_sum[i], fileMeths[chrIndex].meth[rowIndex].data(),
-                        fileMeths[chrIndex].meth[rowIndex].size() * sizeof(char), cudaMemcpyHostToDevice, streams[streamIdx]);
+        cudaMemcpyAsync(d_flatBins[streamIdx] + prefix_sum[i],
+                        fileMeths[chrIndex].meth[rowIndex].data(),
+                        fileMeths[chrIndex].meth[rowIndex].size() * sizeof(char),
+                        cudaMemcpyHostToDevice, streams[streamIdx]);
       }
 
-      cudaMemcpyAsync(d_prefix_sum[streamIdx], prefix_sum.data(), prefix_sum.size() * sizeof(unsigned int), cudaMemcpyHostToDevice, streams[streamIdx]);
-      cudaMemsetAsync(d_cm[streamIdx], 0, goodBins[streamIdx].size() * sizeof(unsigned int), streams[streamIdx]);
-      cudaMemsetAsync(d_cm_1[streamIdx], 0, goodBins[streamIdx].size() * sizeof(unsigned int), streams[streamIdx]);
+      cudaMemcpyAsync(d_prefix_sum[streamIdx], prefix_sum.data(),
+                      prefix_sum.size() * sizeof(unsigned int), cudaMemcpyHostToDevice,
+                      streams[streamIdx]);
+      cudaMemsetAsync(d_cm[streamIdx], 0, goodBins[streamIdx].size() * sizeof(unsigned int),
+                      streams[streamIdx]);
+      cudaMemsetAsync(d_cm_1[streamIdx], 0, goodBins[streamIdx].size() * sizeof(unsigned int),
+                      streams[streamIdx]);
 
       dim3 threadsPerBlock(32, 32);
-      dim3 numBlocks((cumulativeSize[streamIdx] + threadsPerBlock.x) / threadsPerBlock.x, (cumulativeSize[streamIdx] + threadsPerBlock.y) / threadsPerBlock.y);
+      dim3 numBlocks((cumulativeSize[streamIdx] + threadsPerBlock.x) / threadsPerBlock.x,
+                     (cumulativeSize[streamIdx] + threadsPerBlock.y) / threadsPerBlock.y);
 
-      templateMatcher<<<numBlocks, threadsPerBlock, 0, streams[streamIdx]>>>(d_flatBins[streamIdx], cumulativeSize[streamIdx], m, d_prefix_sum[streamIdx], goodBins[streamIdx].size(), d_cm[streamIdx], d_cm_1[streamIdx]);
+      templateMatcher<<<numBlocks, threadsPerBlock, 0, streams[streamIdx]>>>(
+          d_flatBins[streamIdx], cumulativeSize[streamIdx], m, d_prefix_sum[streamIdx],
+          goodBins[streamIdx].size(), d_cm[streamIdx], d_cm_1[streamIdx]);
 
       streamIdx++;
 
-      if (streamIdx == num_streams || (fileIndex == fileMap.size() - 1 && chrIndex == fileMeths.size() - 1))
-      {
-        for (unsigned int j = 0; j < streamIdx; j++)
-        {
+      if (streamIdx == num_streams ||
+          (fileIndex == fileMap.size() - 1 && chrIndex == fileMeths.size() - 1)) {
+        for (unsigned int j = 0; j < streamIdx; j++) {
           cudaStreamSynchronize(streams[j]);
-          unsigned int *h_cm = new unsigned int[goodBins[j].size()]();
+          unsigned int *h_cm   = new unsigned int[goodBins[j].size()]();
           unsigned int *h_cm_1 = new unsigned int[goodBins[j].size()]();
 
-          cudaMemcpy(h_cm, d_cm[j], goodBins[j].size() * sizeof(unsigned int), cudaMemcpyDeviceToHost);
-          cudaMemcpy(h_cm_1, d_cm_1[j], goodBins[j].size() * sizeof(unsigned int), cudaMemcpyDeviceToHost);
+          cudaMemcpy(h_cm, d_cm[j], goodBins[j].size() * sizeof(unsigned int),
+                     cudaMemcpyDeviceToHost);
+          cudaMemcpy(h_cm_1, d_cm_1[j], goodBins[j].size() * sizeof(unsigned int),
+                     cudaMemcpyDeviceToHost);
 
           // std::cout << "file: " << streamInfo[j].first << std::endl;
-          // std::cout << "  chr: " << fileMap[streamInfo[j].first][streamInfo[j].second].chr << std::endl;
+          // std::cout << "  chr: " << fileMap[streamInfo[j].first][streamInfo[j].second].chr <<
+          // std::endl;
 
-          for (unsigned int i = 0; i < goodBins[j].size(); i++)
-          {
+          for (unsigned int i = 0; i < goodBins[j].size(); i++) {
             // std::cout << "    Bin " << i << ":" << std::endl;
             // std::cout << "      cm:" << h_cm[i] << std::endl;
             // std::cout << "      cm_1:" << h_cm_1[i] << std::endl;
-            if (h_cm[i] != 0 && h_cm_1[i] != 0)
-            {
-              sampens[streamInfo[j].first].raw[streamInfo[j].second][goodBins[j][i]] = log((double)h_cm[i] / (double)h_cm_1[i]);
+            if (h_cm[i] != 0 && h_cm_1[i] != 0) {
+              sampens[streamInfo[j].first].raw[streamInfo[j].second][goodBins[j][i]] =
+                  log((double)h_cm[i] / (double)h_cm_1[i]);
               counts[streamInfo[j].first].cm += h_cm[i];
               counts[streamInfo[j].first].cm_1 += h_cm_1[i];
             }
@@ -178,10 +176,8 @@ SampEns sampEn(FileMap &fileMap, const unsigned int m)
   }
   // std::cout << std::endl;
 
-  for (auto &[file, samp] : sampens)
-  {
-    if (counts[file].cm > 0 && counts[file].cm_1 > 0)
-    {
+  for (auto &[file, samp] : sampens) {
+    if (counts[file].cm > 0 && counts[file].cm_1 > 0) {
       samp.agg = log((double)counts[file].cm / (double)counts[file].cm_1);
     }
   }
@@ -223,12 +219,15 @@ SampEns sampEn(FileMap &fileMap, const unsigned int m)
   // cudaMemset(cm, 0, goodBins.size() * sizeof(unsigned int));
   // cudaMemset(cm_1, 0, goodBins.size() * sizeof(unsigned int));
 
-  // cudaMemcpy(d_prefixSum, prefixSum.data(), prefixSum.size() * sizeof(unsigned int), cudaMemcpyHostToDevice);
+  // cudaMemcpy(d_prefixSum, prefixSum.data(), prefixSum.size() * sizeof(unsigned int),
+  // cudaMemcpyHostToDevice);
 
   // dim3 threadsPerBlock(32, 32);
-  // dim3 numBlocks((cumulativeSize + threadsPerBlock.x) / threadsPerBlock.x, (cumulativeSize + threadsPerBlock.y) / threadsPerBlock.y);
+  // dim3 numBlocks((cumulativeSize + threadsPerBlock.x) / threadsPerBlock.x, (cumulativeSize +
+  // threadsPerBlock.y) / threadsPerBlock.y);
 
-  // templateMatcher<<<numBlocks, threadsPerBlock>>>(d_flatBins, cumulativeSize, m, d_prefixSum, goodBins.size(), cm, cm_1);
+  // templateMatcher<<<numBlocks, threadsPerBlock>>>(d_flatBins, cumulativeSize, m, d_prefixSum,
+  // goodBins.size(), cm, cm_1);
 
   // unsigned int *h_cm = new unsigned int[goodBins.size()];
   // unsigned int *h_cm_1 = new unsigned int[goodBins.size()];
@@ -273,7 +272,8 @@ SampEns sampEn(FileMap &fileMap, const unsigned int m)
   // cudaMemcpy(d_cm_1, &h_cm_1, sizeof(unsigned int), cudaMemcpyHostToDevice);
 
   // dim3 threadsPerBlock(32, 32);
-  // dim3 numBlocks((N - m + threadsPerBlock.x) / threadsPerBlock.x, (N - m + threadsPerBlock.y) / threadsPerBlock.y);
+  // dim3 numBlocks((N - m + threadsPerBlock.x) / threadsPerBlock.x, (N - m + threadsPerBlock.y) /
+  // threadsPerBlock.y);
 
   // cudaEvent_t start, stop;
   // cudaEventCreate(&start);
@@ -285,7 +285,8 @@ SampEns sampEn(FileMap &fileMap, const unsigned int m)
 
   // size_t free_mem, total_mem;
   // cudaMemGetInfo(&free_mem, &total_mem);
-  // std::cout << "GPU Memory Used: " << (total_mem - free_mem) / (1024 * 1024) << "MB" << std::endl;
+  // std::cout << "GPU Memory Used: " << (total_mem - free_mem) / (1024 * 1024) << "MB" <<
+  // std::endl;
 
   // float milliseconds = 0;
   // cudaEventElapsedTime(&milliseconds, start, stop);

--- a/method/include/align.h
+++ b/method/include/align.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "methData.h"
 #include "chrData.h"
+#include "methData.h"
 
-void alignSingleWithRef(const std::string &filename, std::vector<ChrPositions> &positions, std::unordered_map<std::string, std::vector<ChrMeth>> &fileMap);
+void    alignSingleWithRef(const std::string &filename, std::vector<ChrPositions> &positions,
+                           std::unordered_map<std::string, std::vector<ChrMeth>> &fileMap);
 FileMap alignWithRef(const std::vector<std::string> &filenames, Reference &ref);

--- a/method/include/align.h
+++ b/method/include/align.h
@@ -4,4 +4,5 @@
 #include "methData.h"
 
 void    alignSingleWithRef(const std::string &filename, Reference &ref, FileMap &fileMap);
-FileMap alignWithRef(const std::vector<std::string> &filenames, Reference &ref);
+FileMap alignWithRef(const std::vector<std::string> &filenames, Reference &ref,
+                     unsigned int n_cores, unsigned int n_threads_per_core);

--- a/method/include/align.h
+++ b/method/include/align.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include "chrData.h"
 #include "methData.h"
 

--- a/method/include/align.h
+++ b/method/include/align.h
@@ -3,6 +3,5 @@
 #include "chrData.h"
 #include "methData.h"
 
-void    alignSingleWithRef(const std::string &filename, std::vector<ChrPositions> &positions,
-                           std::unordered_map<std::string, std::vector<ChrMeth>> &fileMap);
+void    alignSingleWithRef(const std::string &filename, Reference &ref, FileMap &fileMap);
 FileMap alignWithRef(const std::vector<std::string> &filenames, Reference &ref);

--- a/method/include/boost.h
+++ b/method/include/boost.h
@@ -1,16 +1,22 @@
 #pragma once
 
 #include <boost/program_options.hpp>
+#include <string>
+#include <vector>
 
-boost::program_options::variables_map parseCommandLine(int argc, char **argv);
-std::vector<std::string>              getTsvFiles(const boost::program_options::variables_map &vm);
-std::string                           getBed(const boost::program_options::variables_map &vm);
-std::string                           getRef(const boost::program_options::variables_map &vm);
-std::string                           getDetOut(const boost::program_options::variables_map &vm);
-std::string                           getOut(const boost::program_options::variables_map &vm);
-unsigned int                          getNCores(const boost::program_options::variables_map &vm);
-unsigned int getNThreadsPerCore(const boost::program_options::variables_map &vm);
-bool         printSampens(const boost::program_options::variables_map &vm);
+namespace po = boost::program_options;
+
+po::variables_map        parseCommandLine(int argc, char **argv);
+std::vector<std::string> getTsvFiles(const po::variables_map &vm);
+std::string              getBed(const po::variables_map &vm);
+std::string              getRef(const po::variables_map &vm);
+std::string              getDetOut(const po::variables_map &vm);
+std::string              getOut(const po::variables_map &vm);
+unsigned int             getNCores(const po::variables_map &vm);
+unsigned int             getNThreadsPerCore(const po::variables_map &vm);
+unsigned int             getNStreams(const po::variables_map &vm);
+bool                     printSampens(const po::variables_map &vm);
 
 void validate_num_cores(const int cores);
 void validate_num_threads_per_core(const int n_threads_per_core);
+void validate_num_streams(const int n_streams);

--- a/method/include/boost.h
+++ b/method/include/boost.h
@@ -3,9 +3,9 @@
 #include <boost/program_options.hpp>
 
 boost::program_options::variables_map parseCommandLine(int argc, char **argv);
-std::vector<std::string> getTsvFiles(const boost::program_options::variables_map &vm);
-std::string getBed(const boost::program_options::variables_map &vm);
-std::string getChr(const boost::program_options::variables_map &vm);
-std::string getRef(const boost::program_options::variables_map &vm);
-std::string getDetOut(const boost::program_options::variables_map &vm);
-std::string getOut(const boost::program_options::variables_map &vm);
+std::vector<std::string>              getTsvFiles(const boost::program_options::variables_map &vm);
+std::string                           getBed(const boost::program_options::variables_map &vm);
+std::string                           getChr(const boost::program_options::variables_map &vm);
+std::string                           getRef(const boost::program_options::variables_map &vm);
+std::string                           getDetOut(const boost::program_options::variables_map &vm);
+std::string                           getOut(const boost::program_options::variables_map &vm);

--- a/method/include/boost.h
+++ b/method/include/boost.h
@@ -5,7 +5,6 @@
 boost::program_options::variables_map parseCommandLine(int argc, char **argv);
 std::vector<std::string>              getTsvFiles(const boost::program_options::variables_map &vm);
 std::string                           getBed(const boost::program_options::variables_map &vm);
-std::string                           getChr(const boost::program_options::variables_map &vm);
 std::string                           getRef(const boost::program_options::variables_map &vm);
 std::string                           getDetOut(const boost::program_options::variables_map &vm);
 std::string                           getOut(const boost::program_options::variables_map &vm);

--- a/method/include/boost.h
+++ b/method/include/boost.h
@@ -8,3 +8,4 @@ std::string                           getBed(const boost::program_options::varia
 std::string                           getRef(const boost::program_options::variables_map &vm);
 std::string                           getDetOut(const boost::program_options::variables_map &vm);
 std::string                           getOut(const boost::program_options::variables_map &vm);
+bool                                  printSampens(const boost::program_options::variables_map &vm);

--- a/method/include/boost.h
+++ b/method/include/boost.h
@@ -8,4 +8,9 @@ std::string                           getBed(const boost::program_options::varia
 std::string                           getRef(const boost::program_options::variables_map &vm);
 std::string                           getDetOut(const boost::program_options::variables_map &vm);
 std::string                           getOut(const boost::program_options::variables_map &vm);
-bool                                  printSampens(const boost::program_options::variables_map &vm);
+unsigned int                          getNCores(const boost::program_options::variables_map &vm);
+unsigned int getNThreadsPerCore(const boost::program_options::variables_map &vm);
+bool         printSampens(const boost::program_options::variables_map &vm);
+
+void validate_num_cores(const int cores);
+void validate_num_threads_per_core(const int n_threads_per_core);

--- a/method/include/chrData.h
+++ b/method/include/chrData.h
@@ -3,18 +3,18 @@
 #include <string>
 #include <vector>
 
-struct Position {
+struct Interval {
   unsigned int start;
   unsigned int end;
 
-  Position(unsigned int s, unsigned int e) : start(s), end(e) {}
+  Interval(unsigned int s, unsigned int e) : start(s), end(e) {}
 };
 
 struct ChrIntervals {
   std::string           chr;
-  std::vector<Position> intervals;
+  std::vector<Interval> intervals;
 
-  ChrIntervals(const std::string &c, const std::vector<Position> &i) : chr(c), intervals(i) {}
+  ChrIntervals(const std::string &c, const std::vector<Interval> &i) : chr(c), intervals(i) {}
 };
 
 using Intervals = std::vector<ChrIntervals>;
@@ -25,6 +25,8 @@ struct ChrPositions {
 
   ChrPositions(const std::string &c, const std::vector<std::vector<unsigned int>> &p)
       : chr(c), positions(p) {}
+
+  ChrPositions(const std::string &c, size_t size) : chr(c), positions(size) {}
 };
 
 using Reference = std::vector<ChrPositions>;

--- a/method/include/chrData.h
+++ b/method/include/chrData.h
@@ -3,17 +3,15 @@
 #include <string>
 #include <vector>
 
-struct Position
-{
+struct Position {
   unsigned int start;
   unsigned int end;
 
   Position(unsigned int s, unsigned int e) : start(s), end(e) {}
 };
 
-struct ChrIntervals
-{
-  std::string chr;
+struct ChrIntervals {
+  std::string           chr;
   std::vector<Position> intervals;
 
   ChrIntervals(const std::string &c, const std::vector<Position> &i) : chr(c), intervals(i) {}
@@ -21,12 +19,12 @@ struct ChrIntervals
 
 using Intervals = std::vector<ChrIntervals>;
 
-struct ChrPositions
-{
-  std::string chr;
+struct ChrPositions {
+  std::string                            chr;
   std::vector<std::vector<unsigned int>> positions;
 
-  ChrPositions(const std::string &c, const std::vector<std::vector<unsigned int>> &p) : chr(c), positions(p) {}
+  ChrPositions(const std::string &c, const std::vector<std::vector<unsigned int>> &p)
+      : chr(c), positions(p) {}
 };
 
 using Reference = std::vector<ChrPositions>;

--- a/method/include/datarow.h
+++ b/method/include/datarow.h
@@ -2,9 +2,8 @@
 
 #include <string>
 
-struct DataRow
-{
-  std::string chr;
-  unsigned int pos;
+struct DataRow {
+  std::string   chr;
+  unsigned int  pos;
   unsigned char rate;
 };

--- a/method/include/export.h
+++ b/method/include/export.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include "chrData.h"
 #include "samp_en.h"
-#include <string>
 
 void exportDetOut(const std::string &out, const std::vector<std::string> &filenames,
                   SampEns &sampens, Intervals &intervals);

--- a/method/include/export.h
+++ b/method/include/export.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <string>
 #include "chrData.h"
 #include "samp_en.h"
+#include <string>
 
-void exportDetOut(const std::string &out, const std::vector<std::string> &filenames, SampEns &sampens, Intervals &intervals);
+void exportDetOut(const std::string &out, const std::vector<std::string> &filenames,
+                  SampEns &sampens, Intervals &intervals);
 
 void exportOut(const std::string &out, const std::vector<std::string> &filenames, SampEns &sampens);

--- a/method/include/filter.h
+++ b/method/include/filter.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <vector>
 #include "datarow.h"
+#include <vector>
 
 void filter(const std::string &filename, std::vector<DataRow> &data, const std::string &chr);

--- a/method/include/methData.h
+++ b/method/include/methData.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
-struct ChrMeth
-{
-  std::string chr;
+struct ChrMeth {
+  std::string                    chr;
   std::vector<std::vector<char>> meth;
 
   ChrMeth(const std::string &c, const std::vector<std::vector<char>> &p) : chr(c), meth(p) {}

--- a/method/include/methData.h
+++ b/method/include/methData.h
@@ -4,10 +4,10 @@
 #include <vector>
 
 struct ChrMeth {
-  std::string                    chr;
-  std::vector<std::vector<char>> meth;
+  std::string                      chr;
+  std::vector<std::vector<int8_t>> meth;
 
-  ChrMeth(const std::string &c, const std::vector<std::vector<char>> &p) : chr(c), meth(p) {}
+  ChrMeth(const std::string &c, const std::vector<std::vector<int8_t>> &p) : chr(c), meth(p) {}
 };
 
 using FileMeths = std::vector<ChrMeth>;

--- a/method/include/methData.h
+++ b/method/include/methData.h
@@ -8,6 +8,8 @@ struct ChrMeth {
   std::vector<std::vector<int8_t>> meth;
 
   ChrMeth(const std::string &c, const std::vector<std::vector<int8_t>> &p) : chr(c), meth(p) {}
+
+  ChrMeth(const std::string &c, size_t size) : chr(c), meth(size) {}
 };
 
 using FileMeths = std::vector<ChrMeth>;

--- a/method/include/parse_ref.h
+++ b/method/include/parse_ref.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "chrData.h"
 
 Reference parseRef(const std::string &filename, Intervals intervals);

--- a/method/include/parse_search.h
+++ b/method/include/parse_search.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "chrData.h"
 
 Intervals parseSearch(const std::string &filename);

--- a/method/include/parse_search.h
+++ b/method/include/parse_search.h
@@ -1,3 +1,4 @@
+#pragma once
 
 #include "chrData.h"
 

--- a/method/include/samp_en.h
+++ b/method/include/samp_en.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <string>
+#include <unordered_map>
 #include <vector>
 
-#include "datarow.h"
 #include "methData.h"
 
 struct FileSampEns {

--- a/method/include/samp_en.h
+++ b/method/include/samp_en.h
@@ -2,21 +2,19 @@
 
 #include <vector>
 
-#include "methData.h"
 #include "datarow.h"
+#include "methData.h"
 
-struct FileSampEns
-{
+struct FileSampEns {
   std::vector<std::vector<double>> raw;
-  double agg;
+  double                           agg;
 
   // FileSampEns(std::vector<std::vector<double>> s, double t) : raw(std::move(s)), agg(t) {}
 };
 
 using SampEns = std::unordered_map<std::string, FileSampEns>;
 
-struct FileCounts
-{
+struct FileCounts {
   unsigned int cm;
   unsigned int cm_1;
 };

--- a/method/include/samp_en.h
+++ b/method/include/samp_en.h
@@ -22,4 +22,4 @@ struct FileCounts {
 
 using Counts = std::unordered_map<std::string, FileCounts>;
 
-SampEns sampEn(FileMap &fileMap, const unsigned int m);
+SampEns sampEn(FileMap &fileMap, const unsigned int m, unsigned int n_streams);

--- a/method/include/samp_en.h
+++ b/method/include/samp_en.h
@@ -15,8 +15,8 @@ struct FileSampEns {
 using SampEns = std::unordered_map<std::string, FileSampEns>;
 
 struct FileCounts {
-  unsigned int cm;
-  unsigned int cm_1;
+  unsigned long long cm;
+  unsigned long long cm_1;
 };
 
 using Counts = std::unordered_map<std::string, FileCounts>;


### PR DESCRIPTION
Two major changes here - the more robust algorithm for parsing the reference file and the linear time sample entropy algorithm. I will add the suit I have been using to test the parsing as a test case in https://github.com/imallona/yamet/pull/8. 

### Updates

1. linear time sample entropy :)
2. new reference parsing algorithm
3. `.clang-format` file for consistent code formatting
4. granular verbose printing
5. more regulated multiprocessing specifying cores and threads per core - replaces thread creation on demand via futures with a managed thread-pool based approach where threads are pinned to specific cores
6. (partial) documentation of functions used

### New Arguments

1. `--print-bed` - to print the regions bed file
2. `--print-ref` - to print the parsed reference file
3. `--print-tsv` - to print the parsed cell files
4. Sample entropies get printed to stdout by default but can be disabled using `--print-sampens F`
5. `--n-cores` - number of cores to be used during cell file parsing. By default, it is set to 0, which uses $\text{max cores} - \lfloor \log_2(\text{max cores}) \rfloor$. If set to `-1`, it uses all cores.
7. `--n-threads-per-core` - number of threads per core. Every thread handles parsing of a file.
8. `--n-streams` - number of CUDA streams

The tests need to be tweaked to use these flags but they should allow better control over testing.