### PR TITLE
Extend the test suite to take the `g++` version into account

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:       
         matrix:
             gcc-version: [gcc-13, gcc-12, gcc-11]
-            gpp-version: [g++-13, g++-12, g++-11]
+            ## gpp-version: [g++-13, g++-12, g++-11]
         fail-fast: false
     steps:
       - name: Clone
@@ -25,7 +25,7 @@ jobs:
       - name: Build and test_0
         env:
           CC:   ${{ matrix.gcc-version }} 
-          CXX:  ${{ matrix.gpp-version }}
+          ## CXX:  ${{ matrix.gpp-version }}
         run: |
           cd method
           bash build.sh

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -1,20 +1,46 @@
-name: compiler_debug
+name: check_unsupported_g++
 
 on:
   workflow_dispatch:
   pull_request:
-    # types: [assigned, opened, synchronize, reopened]
-    # paths: ['.github/workflows/test.yml', '**/Makefile', '**/*.h', '**/*.hpp', '**/*.c', '**/*.cpp']
-
-# env:
-#   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
-  build_ubuntu_latest_cuda:
+  unsupported_gpp_should_fail:
     runs-on: self-hosted
     strategy:       
         matrix:
-            compiler: [ {cpp: g++, c: gcc}, {cpp: g++-13, c: gcc-13}, {cpp: g++-12, c: gcc-12}, {cpp: g++-11, c: gcc-11} ]
+            compiler: [ {cpp: g++-12, c: gcc-12} ]
+        fail-fast: false
+    steps:
+      - name: Clone
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: Build and test_0
+        env:
+          CC:   ${{ matrix.compiler.c }}
+          CXX:  ${{ matrix.compiler.cpp }}
+        run: |
+          cd method
+          bash build.sh
+
+          cd ../test
+          ~/.local/bin/yamet \
+              --tsv      test_0/in/cell1.bed.gz \
+              --ref      test_0/in/ref.bed.gz \
+              --bed      test_0/in/regions.bed \
+              --det-out  current_test_0.out
+
+          echo 'Diff expected vs produced'
+
+          diff test_0/out/detailed.out \
+               current_test_0.out || test $? -eq 0 || echo 'Failed as expected'
+
+  supported_gpp_should_work:
+    runs-on: self-hosted
+    strategy:       
+        matrix:
+            compiler: [ {cpp: g++-13, c: gcc-13} ]
         fail-fast: false
     steps:
       - name: Clone

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -14,8 +14,7 @@ jobs:
     runs-on: self-hosted
     strategy:       
         matrix:
-            gcc-version: [gcc-13, gcc-12, gcc-11]
-            ## gpp-version: [g++-13, g++-12, g++-11]
+            compiler: [ {cpp: g++, c: gcc}, {cpp: g++-13, c: gcc-13}, {cpp: g++-12, c: gcc-12}, {cpp: g++-11, c: gcc-11} ]
         fail-fast: false
     steps:
       - name: Clone
@@ -24,8 +23,8 @@ jobs:
 
       - name: Build and test_0
         env:
-          CC:   ${{ matrix.gcc-version }} 
-          ## CXX:  ${{ matrix.gpp-version }}
+          CC:   ${{ matrix.compiler.c }}
+          CXX:  ${{ matrix.compiler.cpp }}
         run: |
           cd method
           bash build.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 #   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
-  build_ubuntu_latest_cuda:
+  build_ubuntu_latest:
     runs-on: self-hosted
     steps:
       - name: Clone

--- a/.github/workflows/test_compiler.yml
+++ b/.github/workflows/test_compiler.yml
@@ -1,0 +1,43 @@
+name: compiler_debug
+
+on:
+  workflow_dispatch:
+  pull_request:
+    # types: [assigned, opened, synchronize, reopened]
+    # paths: ['.github/workflows/test.yml', '**/Makefile', '**/*.h', '**/*.hpp', '**/*.c', '**/*.cpp']
+
+# env:
+#   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+jobs:
+  build_ubuntu_latest_cuda:
+    runs-on: self-hosted
+    strategy:       
+        matrix:
+            gcc-version: [gcc-13, gcc-12, gcc-11]
+            gpp-version: [g++-13, g++-12, g++-11]
+        fail-fast: false
+    steps:
+      - name: Clone
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: Build and test_0
+        env:
+          CC:   ${{ matrix.gcc-version }} 
+          CXX:  ${{ matrix.gpp-version }}
+        run: |
+          cd method
+          bash build.sh
+
+          cd ../test
+          ~/.local/bin/yamet \
+              --tsv      test_0/in/cell1.bed.gz \
+              --ref      test_0/in/ref.bed.gz \
+              --bed      test_0/in/regions.bed \
+              --det-out  current_test_0.out
+
+          echo 'Diff expected vs produced'
+
+          diff test_0/out/detailed.out \
+               current_test_0.out


### PR DESCRIPTION
Extend the CI/CD to explore a reduce `g++` versions grid during compilation and testing.