### PR TITLE
Fix action for Tag and Release

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,9 +1,7 @@
 name: cppcheck-annotations
 
 on:
-  # push:
-  pull_request:
-  workflow_dispatch:
+  push:
 
 jobs:
   build:

--- a/.github/workflows/tar.yml
+++ b/.github/workflows/tar.yml
@@ -32,9 +32,9 @@ jobs:
         run: |
           ls method/install
           ls LICENSE
-          tar -czvf yamet-${{ github.ref_name }}.tar.gz LICENSE -C method/install .
+          tar -czvf yamet-${{ github.ref_name }}-MacOSX-arm64.tar.gz LICENSE -C method/install .
 
       - name: Create GitHub Release and upload tarball
         uses: softprops/action-gh-release@v2
         with:
-          files: yamet-${{ github.ref_name }}.tar.gz
+          files: yamet-${{ github.ref_name }}-MacOSX-arm64.tar.gz

--- a/.github/workflows/tar.yml
+++ b/.github/workflows/tar.yml
@@ -18,7 +18,12 @@ jobs:
       - name: Build
         run: |
           cd method
-          cmake -Bbuild -DCMAKE_INSTALL_PREFIX=install -DCMAKE_BUILD_TYPE=Release -S.
+          VERSION=$(echo ${{ github.ref_name }} | sed 's/^v//')
+          cmake -S. \
+            -Bbuild \
+            -DVERSION=$VERSION
+            -DCMAKE_INSTALL_PREFIX=install \
+            -DCMAKE_BUILD_TYPE=Release
           cmake --build build --config Release
           cmake --install build
 

--- a/.github/workflows/tar.yml
+++ b/.github/workflows/tar.yml
@@ -18,23 +18,46 @@ jobs:
       - name: Build
         run: |
           cd method
-          VERSION=$(echo ${{ github.ref_name }} | sed 's/^v//; s/-.*$//')
           cmake -S. \
             -Bbuild \
             -DZLIB_ROOT="/opt/homebrew/opt/zlib" \
-            -DVERSION=$VERSION \
+            -DVERSION=${{ github.ref_name }} \
             -DCMAKE_INSTALL_PREFIX=install \
+            -DCPACK_GENERATOR=TGZ \
+            -DCPACK_PACKAGING_INSTALL_PREFIX=/ \
             -DCMAKE_BUILD_TYPE=Release
           cmake --build build --config Release
-          cmake --install build
-
-      - name: Tar
-        run: |
-          ls method/install
-          ls LICENSE
-          tar -czvf yamet-${{ github.ref_name }}-MacOSX-arm64.tar.gz LICENSE -C method/install .
+          cpack --config build/CPackConfig.cmake --verbose
 
       - name: Create GitHub Release and upload tarball
         uses: softprops/action-gh-release@v2
         with:
-          files: yamet-${{ github.ref_name }}-MacOSX-arm64.tar.gz
+          files: method/yamet-${{ github.ref_name }}-*-*.tar.gz
+
+  build-linux:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: sudo apt update && sudo apt install -y libboost-program-options-dev zlib1g-dev
+
+      - name: Build
+        run: |
+          cd method
+          cmake -S. \
+            -Bbuild \
+            -DZLIB_ROOT="/usr/include" \
+            -DVERSION=${{ github.ref_name }} \
+            -DCMAKE_INSTALL_PREFIX=install \
+            -DCPACK_GENERATOR=DEB \
+            -DCPACK_PACKAGING_INSTALL_PREFIX=/usr \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build build --config Release
+          cpack --config build/CPackConfig.cmake --verbose
+
+      - name: Create GitHub Release and upload tarball
+        uses: softprops/action-gh-release@v2
+        with:
+          files: method/yamet-${{ github.ref_name }}-Linux-*.deb

--- a/.github/workflows/tar.yml
+++ b/.github/workflows/tar.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: brew install boost
+        run: brew update && brew install boost
 
       - name: Build
         run: |

--- a/.github/workflows/tar.yml
+++ b/.github/workflows/tar.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Build
         run: |
           cd method
-          VERSION=$(echo ${{ github.ref_name }} | sed 's/^v//')
+          VERSION=$(echo ${{ github.ref_name }} | sed 's/^v//; s/-.*$//')
           cmake -S. \
             -Bbuild \
-            -DVERSION=$VERSION
+            -DVERSION=$VERSION \
             -DCMAKE_INSTALL_PREFIX=install \
             -DCMAKE_BUILD_TYPE=Release
           cmake --build build --config Release

--- a/.github/workflows/tar.yml
+++ b/.github/workflows/tar.yml
@@ -21,6 +21,7 @@ jobs:
           VERSION=$(echo ${{ github.ref_name }} | sed 's/^v//; s/-.*$//')
           cmake -S. \
             -Bbuild \
+            -DZLIB_ROOT="/opt/homebrew/opt/zlib" \
             -DVERSION=$VERSION \
             -DCMAKE_INSTALL_PREFIX=install \
             -DCMAKE_BUILD_TYPE=Release

--- a/method/CMakeLists.txt
+++ b/method/CMakeLists.txt
@@ -2,7 +2,12 @@
 cmake_minimum_required(VERSION 3.15)
 
 # Project name and version
-project(yamet VERSION 0.1.0 LANGUAGES CXX)
+project(yamet VERSION 0.0.0 LANGUAGES CXX)
+
+# Allow overriding the version from the command line
+if(DEFINED VERSION)
+  project(yamet VERSION ${VERSION} LANGUAGES CXX)
+endif()
 
 # Check for the compiler and its version
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/method/CMakeLists.txt
+++ b/method/CMakeLists.txt
@@ -6,7 +6,8 @@ project(yamet VERSION 0.0.0 LANGUAGES CXX)
 
 # Allow overriding the version from the command line
 if(DEFINED VERSION)
-  project(yamet VERSION ${VERSION} LANGUAGES CXX)
+  string(REGEX REPLACE "^v([0-9]+\\.[0-9]+\\.[0-9]+).*" "\\1" CLEANED_VERSION ${VERSION})
+  project(yamet VERSION ${CLEANED_VERSION} LANGUAGES CXX)
 endif()
 
 # Check for the compiler and its version
@@ -56,3 +57,23 @@ target_include_directories(yamet PUBLIC include ${CMAKE_BINARY_DIR}/config)
 # Install target (binary and headers)
 install(TARGETS yamet DESTINATION bin)
 install(DIRECTORY include/ DESTINATION include)
+
+# General package metadata
+set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
+set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Yet Another Methylation Entropy Tool")
+set(CPACK_PACKAGE_VENDOR "Atreya Choudhury")
+set(CPACK_PACKAGE_CONTACT "atreyachoudhury@hotmail.com")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/imallona/yamet")
+set(CPACK_PACKAGE_LICENSE "GPL-3.0-only")
+
+# Debian-specific metadata
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "zlib1g-dev (>= 1.2.0), libboost-program-options-dev (>= 1.70.0)")
+set(CPACK_DEBIAN_PACKAGE_SECTION "utils")
+set(CPACK_DEBIAN_ARCHITECTURE ${CMAKE_SYSTEM_PROCESSOR})
+
+# Optional: Specify the package output file name
+set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${VERSION}-${CMAKE_SYSTEM_NAME}-${CPACK_DEBIAN_ARCHITECTURE}")
+
+# Add CPack configuration for packaging
+include(CPack)


### PR DESCRIPTION
### New
- use `CPack` for packaging. Packaging for `*-Darwin-arm64.tar.gz` (usable via `brew`) and `*-Linux-x86_64.deb` for now.

### Fixes
- update brew taps before installing
- pull version info from tag during build